### PR TITLE
use correct placeholders of league skeleton

### DIFF
--- a/src/PackagerNewCommand.php
+++ b/src/PackagerNewCommand.php
@@ -101,8 +101,28 @@ class PackagerNewCommand extends Command
         // Replacing skeleton namespaces
         $this->info('Replacing skeleton namespaces...');
             $this->helper->replaceAndSave($fullPath.'/src/SkeletonClass.php', 'namespace League\Skeleton;', 'namespace '.$vendor.'\\'.$name.';');
-            $search =   ['thephpleague/:package_name',  'league/:package_name',    '"php"',            'League\\\\Skeleton\\\\',       'League\\\\Skeleton\\\\Test\\\\'];
-            $replace =  [$vendor.'/'.$name,             $vendor.'/'.$name,         $requireSupport,    $vendor.'\\\\'.$name.'\\\\',    $vendor.'\\\\'.$name.'\\\\Test\\\\'];
+            $search =   [
+                ':vendor',
+                ':package_name',
+                ':vendor\\\\:package_name\\\\',
+                ':vendor/:package_name',
+                'thephpleague/:package_name',
+                'league/:package_name',
+                '"php"',
+                'League\\\\Skeleton\\\\',
+                'League\\\\Skeleton\\\\Test\\\\'
+            ];
+            $replace =  [
+                $vendor,
+                $name,
+                $vendor.'\\\\'.$name.'\\\\',
+                $vendor.'/'.$name,
+                $vendor.'/'.$name,
+                $vendor.'/'.$name,
+                $requireSupport,
+                $vendor.'\\\\'.$name.'\\\\',
+                $vendor.'\\\\'.$name.'\\\\Test\\\\'
+            ];
             $this->helper->replaceAndSave($fullPath.'/composer.json', $search, $replace);
         $bar->advance();
 


### PR DESCRIPTION
`composer.json` contained a bunch of unreplaced placeholders. Not sure how that package could have worked for you guys in the last few months, but from what I can see the placeholders were changed on Nov 27, 2015

https://github.com/thephpleague/skeleton/commit/d048eb97f87bb2546f1444528a75d109b70ae2e8