### PR TITLE
Composer dump-autoload after new package.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Laravel Packager
 
-[![Latest Version on Packagist][ico-version]][link-packagist]
-[![Total Downloads][ico-downloads]][link-downloads]
-[![Software License][ico-license]](license.md)
+[![Latest Stable Version](https://poser.pugx.org/jeroen-g/laravel-packager/v/stable)](https://packagist.org/packages/jeroen-g/laravel-packager)
+[![Total Downloads](https://poser.pugx.org/jeroen-g/laravel-packager/downloads)](https://packagist.org/packages/jeroen-g/laravel-packager)
+[![License](https://poser.pugx.org/jeroen-g/laravel-packager/license)](https://packagist.org/packages/jeroen-g/laravel-packager)
 
 This package provides you with a simple tool to set up a new package and it will let you focus on the development of the package instead of the boilerplate.
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Laravel Packager
 
-[![Latest Stable Version](https://poser.pugx.org/jeroen-g/laravel-packager/v/stable)](https://packagist.org/packages/jeroen-g/laravel-packager)
-[![Total Downloads](https://poser.pugx.org/jeroen-g/laravel-packager/downloads)](https://packagist.org/packages/jeroen-g/laravel-packager)
-[![License](https://poser.pugx.org/jeroen-g/laravel-packager/license)](https://packagist.org/packages/jeroen-g/laravel-packager)
+[![Latest Version on Packagist][ico-version]][link-packagist]
+[![Total Downloads][ico-downloads]][link-downloads]
+[![Software License][ico-license]](license.md)
 
 This package provides you with a simple tool to set up a new package and it will let you focus on the development of the package instead of the boilerplate.
 

--- a/src/PackagerHelper.php
+++ b/src/PackagerHelper.php
@@ -185,4 +185,13 @@ class PackagerHelper
         @unlink($zipFile);
         return $this;
     }
+    
+    /**
+     * New composer instance that dumps autoloads.
+     * @return mixed
+     */
+    public function dumpAutoloads()
+    {
+        return (app()['composer'])->dumpAutoloads();
+    }
 }

--- a/src/PackagerListCommand.php
+++ b/src/PackagerListCommand.php
@@ -26,25 +26,7 @@ class PackagerListCommand extends Command
      * @var string
      */
     protected $description = 'List all locally installed packages.';
-    
-    /**
-     * Instance of the composer class.
-     *
-     * @var Composer
-     */
-    private $composer;
-    
-    
-    /**
-     * Create a new command instance.
-     *
-     * @param Filesystem $filesystem
-     */
-    public function __construct()
-    {
-        parent::__construct();
-        $this->composer = app()['composer'];
-    }
+
     /**
      * Execute the console command.
      *
@@ -63,7 +45,5 @@ class PackagerListCommand extends Command
 
         $headers = ['Package', 'Path'];
         $this->table($headers, $packages);
-        
-        $this->composer->dumpAutoloads();
     }
 }

--- a/src/PackagerListCommand.php
+++ b/src/PackagerListCommand.php
@@ -63,7 +63,7 @@ class PackagerListCommand extends Command
 
         $headers = ['Package', 'Path'];
         $this->table($headers, $packages);
+        
+        $this->composer->dumpAutoloads();
     }
-    
-    $this->composer->dumpAutoloads();
 }

--- a/src/PackagerListCommand.php
+++ b/src/PackagerListCommand.php
@@ -26,7 +26,25 @@ class PackagerListCommand extends Command
      * @var string
      */
     protected $description = 'List all locally installed packages.';
-
+    
+    /**
+     * Instance of the composer class.
+     *
+     * @var Composer
+     */
+    private $composer;
+    
+    
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->composer = app()['composer'];
+    }
     /**
      * Execute the console command.
      *
@@ -46,4 +64,6 @@ class PackagerListCommand extends Command
         $headers = ['Package', 'Path'];
         $this->table($headers, $packages);
     }
+    
+    $this->composer->dumpAutoloads();
 }

--- a/src/PackagerNewCommand.php
+++ b/src/PackagerNewCommand.php
@@ -159,7 +159,7 @@ class PackagerNewCommand extends Command
         $bar = null;
 
         //composer dump-autoload to identify new MyPackageServiceProvider
-        $this->composer->dumpAutoloads();
+        $this->helper->dumpAutoloads();
     }
 
     protected function interactiveReplace($vendor, $name, $fullPath)

--- a/src/PackagerNewCommand.php
+++ b/src/PackagerNewCommand.php
@@ -35,13 +35,6 @@ class PackagerNewCommand extends Command
     protected $helper;
 
     /**
-     * Instance of the composer class.
-     *
-     * @var Composer
-     */
-    protected $composer;
-
-    /**
      * Create a new command instance.
      *
      * @return void
@@ -50,7 +43,6 @@ class PackagerNewCommand extends Command
     {
         parent::__construct();
         $this->helper = $helper;
-        $this->composer = app()['composer'];
     }
 
     /**

--- a/src/PackagerNewCommand.php
+++ b/src/PackagerNewCommand.php
@@ -35,6 +35,13 @@ class PackagerNewCommand extends Command
     protected $helper;
 
     /**
+     * Instance of the composer class.
+     *
+     * @var Composer
+     */
+    protected $composer;
+
+    /**
      * Create a new command instance.
      *
      * @return void
@@ -43,6 +50,7 @@ class PackagerNewCommand extends Command
     {
         parent::__construct();
         $this->helper = $helper;
+        $this->composer = app()['composer'];
     }
 
     /**
@@ -149,6 +157,9 @@ class PackagerNewCommand extends Command
         $this->info('Package created successfully!');
         $this->output->newLine(2);
         $bar = null;
+
+        //composer dump-autoload to identify new MyPackageServiceProvider
+        $this->composer->dumpAutoloads();
     }
 
     protected function interactiveReplace($vendor, $name, $fullPath)


### PR DESCRIPTION
Hello,

After I ran the command:

`php artisan packager:new MyVendor MyPackage`

the laravel app can not locate the generated MyPackageServiceProvider.php. The file is succesfully registered in app/config.php. The reason that it can not locate it, is because we need to run 

`composer dump-autoload.`

I added this functionality in the PackagerNewCommand.php. It runs `composer dump-autoload` after installation. 

Also you have a documentation bug which i fixed using https://poser.pugx.org/ package.

Regards,
Athanasios Ntavelis
 