### PR TITLE
Add --dev param to composer require

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ This package provides you with a simple tool to set up a new package and it will
 Via Composer
 
 ```bash
-$ composer require jeroen-g/laravel-packager
+$ composer require jeroen-g/laravel-packager --dev
 ```
 
 If you do not run Laravel 5.5 (or higher), then add the service provider in `config/app.php`:


### PR DESCRIPTION
Adding `--dev` param to composer require as per https://github.com/Jeroen-G/laravel-packager/issues/54#issuecomment-412326270 discussion.
Installing only on development will avoid extra deploy latency/overhead in production, reduce risk and avoid issues loading service provider as it's not autodiscovered if it's not installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeroen-g/laravel-packager/55)
<!-- Reviewable:end -->
