### PR TITLE
Will check if git clone was successful

### DIFF
--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -82,9 +82,12 @@ class GitPackage extends Command
         $this->conveyor->checkIfPackageExists();
         $this->makeProgress();
 
+        // Create the package directory
+        $this->info('Creating packages directory...');
+        $this->conveyor->makeDir($this->conveyor->packagesPath());
+
         // Clone the repository
         $this->info('Cloning repository...');
-
         exec("git clone $source ".$this->conveyor->packagePath(), $output, $exit_code);
 
         if ($exit_code != 0) {

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -90,6 +90,7 @@ class GitPackage extends Command
         if ($exit_code != 0) {
             $this->error('Unable to clone repository');
             $this->warn('Please check credentials and try again');
+
             return;
         }
 

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -85,7 +85,7 @@ class GitPackage extends Command
         // Clone the repository
         $this->info('Cloning repository...');
 
-        exec("git clone $source " . $this->conveyor->packagePath(), $output, $exit_code);
+        exec("git clone $source ".$this->conveyor->packagePath(), $output, $exit_code);
 
         if ($exit_code != 0) {
             $this->error('Unable to clone repository');

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -128,4 +128,3 @@ class GitPackage extends Command
         $this->conveyor->package($package);
     }
 }
-

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -116,10 +116,10 @@ class GitPackage extends Command
         $pieces = explode('/', $origin);
 
         if (Str::contains($origin, 'https')) {
-            $vendor  = $pieces[3];
+            $vendor = $pieces[3];
             $package = $pieces[4];
         } else {
-            $vendor  = explode(':', $pieces[0])[1];
+            $vendor = explode(':', $pieces[0])[1];
             $package = rtrim($pieces[1], '.git');
         }
 

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -2,6 +2,7 @@
 
 namespace JeroenG\Packager\Commands;
 
+use Illuminate\Support\Str;
 use JeroenG\Packager\Conveyor;
 use JeroenG\Packager\Wrapping;
 use Illuminate\Console\Command;
@@ -68,10 +69,9 @@ class GitPackage extends Command
         // Common variables
         $source = $this->argument('url');
         $origin = rtrim(strtolower($source), '/');
-        $pieces = explode('/', $origin);
+
         if (is_null($this->argument('vendor')) || is_null($this->argument('name'))) {
-            $this->conveyor->vendor($pieces[3]);
-            $this->conveyor->package($pieces[4]);
+            $this->setGitVendorAndPackage($origin);
         } else {
             $this->conveyor->vendor($this->argument('vendor'));
             $this->conveyor->package($this->argument('name'));
@@ -82,19 +82,22 @@ class GitPackage extends Command
         $this->conveyor->checkIfPackageExists();
         $this->makeProgress();
 
-        // Create the package directory
-        $this->info('Creating packages directory...');
-        $this->conveyor->makeDir($this->conveyor->packagesPath());
+        // Clone the repository
+        $this->info('Cloning repository...');
+
+        exec("git clone $source " . $this->conveyor->packagePath(), $output, $exit_code);
+
+        if ($exit_code != 0) {
+            $this->error('Unable to clone repository');
+            $this->warn('Please check credentials and try again');
+            return;
+        }
+
         $this->makeProgress();
 
         // Create the vendor directory
         $this->info('Creating vendor...');
         $this->conveyor->makeDir($this->conveyor->vendorPath());
-        $this->makeProgress();
-
-        // Clone the repository
-        $this->info('Cloning repository...');
-        exec("git clone $source ".$this->conveyor->packagePath());
         $this->makeProgress();
 
         // Composer dump-autoload to identify new service provider
@@ -107,4 +110,21 @@ class GitPackage extends Command
         // Finished creating the package, end of the progress bar
         $this->finishProgress('Package cloned successfully!');
     }
+
+    protected function setGitVendorAndPackage($origin)
+    {
+        $pieces = explode('/', $origin);
+
+        if (Str::contains($origin, 'https')) {
+            $vendor  = $pieces[3];
+            $package = $pieces[4];
+        } else {
+            $vendor  = explode(':', $pieces[0])[1];
+            $package = rtrim($pieces[1], '.git');
+        }
+
+        $this->conveyor->vendor($vendor);
+        $this->conveyor->package($package);
+    }
 }
+


### PR DESCRIPTION
This PR adds functionality to check if the `git clone` step was successful.

A check for the exit code from the `exec()` function has now been added if there are any failures (authentication, does not exist etc). In the event the `git clone` was not successful, the script prints a error message and exits.

'packages/' folder (and additional folders) will not be created, and both `config/app.php & `composer.json` files will not be updated.

A new `setGitVendorAndPackage()` method has been added to the class. This replaces the previous code and now checks if the url passes contains `https`. If it doesnt, it will assume the `ssh` version was used (e.g. `git@github.com:Jeroen-G/laravel-packager.git`).

**Note:** The creation of the `packages` step has been removed, I found this was no required when using `git clone`. This may need further testing.
    