### PR TITLE
Convert vendor and package to camel case when installing package from git

### DIFF
--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -82,9 +82,12 @@ class GitPackage extends Command
         $this->conveyor->checkIfPackageExists();
         $this->makeProgress();
 
+        // Create the package directory
+        $this->info('Creating packages directory...');
+        $this->conveyor->makeDir($this->conveyor->packagesPath());
+
         // Clone the repository
         $this->info('Cloning repository...');
-
         exec("git clone $source ".$this->conveyor->packagePath(), $output, $exit_code);
 
         if ($exit_code != 0) {

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -90,6 +90,7 @@ class GitPackage extends Command
         if ($exit_code != 0) {
             $this->error('Unable to clone repository');
             $this->warn('Please check credentials and try again');
+
             return;
         }
 

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -85,7 +85,7 @@ class GitPackage extends Command
         // Clone the repository
         $this->info('Cloning repository...');
 
-        exec("git clone $source " . $this->conveyor->packagePath(), $output, $exit_code);
+        exec("git clone $source ".$this->conveyor->packagePath(), $output, $exit_code);
 
         if ($exit_code != 0) {
             $this->error('Unable to clone repository');

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -128,4 +128,3 @@ class GitPackage extends Command
         $this->conveyor->package($package);
     }
 }
-

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -116,10 +116,10 @@ class GitPackage extends Command
         $pieces = explode('/', $origin);
 
         if (Str::contains($origin, 'https')) {
-            $vendor  = $pieces[3];
+            $vendor = $pieces[3];
             $package = $pieces[4];
         } else {
-            $vendor  = explode(':', $pieces[0])[1];
+            $vendor = explode(':', $pieces[0])[1];
             $package = rtrim($pieces[1], '.git');
         }
 

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -2,6 +2,7 @@
 
 namespace JeroenG\Packager\Commands;
 
+use Illuminate\Support\Str;
 use JeroenG\Packager\Conveyor;
 use JeroenG\Packager\Wrapping;
 use Illuminate\Console\Command;
@@ -68,10 +69,9 @@ class GitPackage extends Command
         // Common variables
         $source = $this->argument('url');
         $origin = rtrim(strtolower($source), '/');
-        $pieces = explode('/', $origin);
+
         if (is_null($this->argument('vendor')) || is_null($this->argument('name'))) {
-            $this->conveyor->vendor($pieces[3]);
-            $this->conveyor->package($pieces[4]);
+            $this->setGitVendorAndPackage($origin);
         } else {
             $this->conveyor->vendor($this->argument('vendor'));
             $this->conveyor->package($this->argument('name'));
@@ -82,19 +82,22 @@ class GitPackage extends Command
         $this->conveyor->checkIfPackageExists();
         $this->makeProgress();
 
-        // Create the package directory
-        $this->info('Creating packages directory...');
-        $this->conveyor->makeDir($this->conveyor->packagesPath());
+        // Clone the repository
+        $this->info('Cloning repository...');
+
+        exec("git clone $source " . $this->conveyor->packagePath(), $output, $exit_code);
+
+        if ($exit_code != 0) {
+            $this->error('Unable to clone repository');
+            $this->warn('Please check credentials and try again');
+            return;
+        }
+
         $this->makeProgress();
 
         // Create the vendor directory
         $this->info('Creating vendor...');
         $this->conveyor->makeDir($this->conveyor->vendorPath());
-        $this->makeProgress();
-
-        // Clone the repository
-        $this->info('Cloning repository...');
-        exec("git clone $source ".$this->conveyor->packagePath());
         $this->makeProgress();
 
         // Composer dump-autoload to identify new service provider
@@ -107,4 +110,21 @@ class GitPackage extends Command
         // Finished creating the package, end of the progress bar
         $this->finishProgress('Package cloned successfully!');
     }
+
+    protected function setGitVendorAndPackage($origin)
+    {
+        $pieces = explode('/', $origin);
+
+        if (Str::contains($origin, 'https')) {
+            $vendor  = $pieces[3];
+            $package = $pieces[4];
+        } else {
+            $vendor  = explode(':', $pieces[0])[1];
+            $package = rtrim($pieces[1], '.git');
+        }
+
+        $this->conveyor->vendor($vendor);
+        $this->conveyor->package($package);
+    }
 }
+

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -141,7 +141,7 @@ class Wrapping
     }
 
     /**
-     * Format vendor and package strings.
+     * Format vendor and package strings to camel case.
      *
      * @param  string $vendor
      * @param  string $package

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -150,11 +150,9 @@ class Wrapping
     protected function formatVars($vendor, $package)
     {
         foreach (['vendor', 'package'] as $var) {
-            if (strpos(${$var}, '-') !== false) {
-                ${$var} = collect(explode('-', ${$var}))->map(function ($segment, $key) {
-                    return ucfirst($segment);
-                })->implode('');
-            }
+            ${$var} = collect(explode('-', ${$var}))->map(function ($segment, $key) {
+                return ucfirst($segment);
+            })->implode('');
         }
 
         return [$vendor, $package];

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -87,6 +87,8 @@ class Wrapping
      */
     public function addToComposer($vendor, $package)
     {
+        list($vendor, $package) = $this->formatVars($vendor, $package);
+
         return $this->replace('"psr-4": {', '"psr-4": {
             "'.$vendor.'\\\\'.$package.'\\\\": "packages/'.$vendor.'/'.$package.'/src",')
                     ->fillInFile(base_path('composer.json'));
@@ -114,6 +116,8 @@ class Wrapping
      */
     public function addToProviders($vendor, $package)
     {
+        list($vendor, $package) = $this->formatVars($vendor, $package);
+
         return $this->replace('
          * Package Service Providers...
          */', '
@@ -134,5 +138,18 @@ class Wrapping
     {
         return $this->replace($vendor.'\\'.$package.'\\'.$package.'ServiceProvider::class,', '')
                     ->fillInFile(config_path('app.php'));
+    }
+
+    protected function formatVars($vendor, $package)
+    {
+        foreach (['vendor', 'package'] as $var) {
+            if (strpos(${$var}, '-') !== false) {
+                ${$var} = collect(explode('-', ${$var}))->map(function ($segment, $key) {
+                    return ucfirst($segment);
+                })->implode('');
+            }
+        }
+
+        return [$vendor, $package];
     }
 }

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -140,6 +140,13 @@ class Wrapping
                     ->fillInFile(config_path('app.php'));
     }
 
+    /**
+     * Format vendor and package strings.
+     *
+     * @param  string $vendor
+     * @param  string $package
+     * @return array
+     */
     protected function formatVars($vendor, $package)
     {
         foreach (['vendor', 'package'] as $var) {


### PR DESCRIPTION
Closes #71, Closes #65.

This formats the `vendor` and `package` when using the `php artisan packager:git` command.

Using  `->formatVars()` method, both are changed to title case. If there are any hyphens, the string is split, changed to title case and concatenated.