### PR TITLE
Use Composer path repositories to install packages in parent project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 *.sublime-project
 *.sublime-workspace
+testbench/

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/guzzle": "~6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7",
+        "phpunit/phpunit": "~8",
         "orchestra/testbench": "~3"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ $ php artisan packager:new MyVendor MyPackage
 ```
 
 **Result:**
-The command will handle practically everything for you. It will create a packages directory, creates the vendor and package directory in it, pulls in a skeleton package, sets up composer.json, creates a service provider, registers the package in config/app.php and the app's composer.json.
+The command will handle practically everything for you. It will create a packages directory, creates the vendor and package directory in it, pulls in a skeleton package, sets up composer.json and creates a service provider.
 
 **Options:**
 ```bash
@@ -65,7 +65,7 @@ $ php artisan packager:git https://github.com/author/repository
 ```
 
 **Result:**
-This will register the package in `config/app.php` and in the app's `composer.json` file.
+This will register the package in the app's `composer.json` file.
 If the `packager:git` command is used, the entire Git repository is cloned. If `packager:get` is used, the package will be downloaded, without a repository. This also works with Bitbucket repositories, but you have to provide the flag `--host=bitbucket` for the `packager:get` command.
 
 **Options:**

--- a/src/Commands/DisablePackage.php
+++ b/src/Commands/DisablePackage.php
@@ -72,11 +72,9 @@ class DisablePackage extends Command
         $this->info('Disabling package '.$this->conveyor->vendor().'\\'.$this->conveyor->package().'...');
         $this->makeProgress();
 
-        // Composer dump-autoload to remove service provider
-        $this->info('Dumping autoloads and undiscovering package...');
-        $this->wrapping->removeFromComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->removeFromProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
+        // Uninstall the package
+        $this->info('Uninstalling package...');
+        $this->conveyor->uninstallPackage();
         $this->makeProgress();
 
         // Finished removing the package, end of the progress bar

--- a/src/Commands/EnablePackage.php
+++ b/src/Commands/EnablePackage.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 use JeroenG\Packager\ProgressBar;
 
 /**
- * remove an existing package.
+ * Enable an existing package.
  *
  * @author JeroenG
  **/
@@ -72,11 +72,9 @@ class EnablePackage extends Command
         $this->info('Enabling package '.$this->conveyor->vendor().'\\'.$this->conveyor->package().'...');
         $this->makeProgress();
 
-        // Composer dump-autoload to remove service provider
-        $this->info('Dumping autoloads and undiscovering package...');
-        $this->wrapping->addToComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->addToProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
+        // Install the package
+        $this->info('Installing package...');
+        $this->conveyor->installPackage();
         $this->makeProgress();
 
         // Finished removing the package, end of the progress bar

--- a/src/Commands/GetPackage.php
+++ b/src/Commands/GetPackage.php
@@ -107,11 +107,9 @@ class GetPackage extends Command
         }
         $this->makeProgress();
 
-        // Composer dump-autoload to identify new service provider
-        $this->info('Dumping autoloads and discovering package...');
-        $this->wrapping->addToComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->addToProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
+        // Install the package
+        $this->info('Installing package...');
+        $this->conveyor->installPackage();
         $this->makeProgress();
 
         // Finished creating the package, end of the progress bar

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -104,11 +104,8 @@ class GitPackage extends Command
         $this->conveyor->makeDir($this->conveyor->vendorPath());
         $this->makeProgress();
 
-        // Composer dump-autoload to identify new service provider
-        $this->info('Dumping autoloads and discovering package...');
-        $this->wrapping->addToComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->addToProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
+        $this->info('Installing package...');
+        $this->conveyor->installPackage();
         $this->makeProgress();
 
         // Finished creating the package, end of the progress bar

--- a/src/Commands/ListPackages.php
+++ b/src/Commands/ListPackages.php
@@ -31,11 +31,14 @@ class ListPackages extends Command
     public function handle()
     {
         $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+        $packages_path = base_path('packages/');
+        $repositories = $composer['repositories'] ?? [];
         $packages = [];
-
-        foreach ($composer['autoload']['psr-4'] as $package => $path) {
-            if ($package !== 'App\\') {
-                $packages[] = [rtrim($package, '\\'), $path];
+        foreach ($repositories as $name => $info) {
+            $path = $info['url'];
+            $pattern = '{'.addslashes($packages_path).'(.*)$}';
+            if (preg_match($pattern, $path, $match)) {
+                $packages[] = explode(DIRECTORY_SEPARATOR, $match[1]);
             }
         }
 

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -133,11 +133,10 @@ class NewPackage extends Command
 
         $this->makeProgress();
 
-        // Composer dump-autoload to identify new service provider
-        $this->info('Dumping autoloads and discovering package...');
-        $this->wrapping->addToComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->addToProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
+        // Add path repository to composer.json and install package
+        $this->info('Installing package...');
+        $this->conveyor->installPackage();
+
         $this->makeProgress();
 
         // Finished creating the package, end of the progress bar

--- a/src/Commands/RemovePackage.php
+++ b/src/Commands/RemovePackage.php
@@ -70,6 +70,11 @@ class RemovePackage extends Command
         $this->info('Removing package '.$this->conveyor->vendor().'\\'.$this->conveyor->package().'...');
         $this->makeProgress();
 
+        // Uninstall the package
+        $this->info('Uninstalling package...');
+        $this->conveyor->uninstallPackage();
+        $this->makeProgress();
+
         // remove the package directory
         $this->info('Removing packages directory...');
         $this->conveyor->removeDir($this->conveyor->packagePath());
@@ -82,13 +87,6 @@ class RemovePackage extends Command
         } else {
             $this->info('Continuing...');
         }
-        $this->makeProgress();
-
-        // Composer dump-autoload to remove service provider
-        $this->info('Dumping autoloads and undiscovering package...');
-        $this->wrapping->removeFromComposer($this->conveyor->vendor(), $this->conveyor->package());
-        $this->wrapping->removeFromProviders($this->conveyor->vendor(), $this->conveyor->package());
-        $this->conveyor->dumpAutoloads();
         $this->makeProgress();
 
         // Finished removing the package, end of the progress bar

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -2,7 +2,7 @@
 
 namespace JeroenG\Packager\Tests;
 
-use Artisan;
+use Illuminate\Support\Facades\Artisan;
 
 class IntegratedTest extends TestCase
 {
@@ -15,7 +15,8 @@ class IntegratedTest extends TestCase
 
     public function test_get_existing_package()
     {
-        Artisan::call('packager:get', ['url' => 'https://github.com/Jeroen-G/packager-skeleton', 'vendor' => 'MyVendor', 'name' => 'MyPackage']);
+        Artisan::call('packager:get',
+            ['url' => 'https://github.com/Jeroen-G/packager-skeleton', 'vendor' => 'MyVendor', 'name' => 'MyPackage']);
 
         $this->seeInConsoleOutput('Package downloaded successfully!');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,50 +8,42 @@ abstract class TestCase extends TestBench
 {
     use TestHelper;
 
+    protected const TEST_APP_TEMPLATE = __DIR__.'/../testbench/template';
+    protected const TEST_APP = __DIR__.'/../testbench/laravel';
+
+    public static function setUpBeforeClass():void
+    {
+        if (!file_exists(self::TEST_APP_TEMPLATE)) {
+            self::setUpLocalTestbench();
+        }
+        parent::setUpBeforeClass();
+    }
+
+
+    protected function getBasePath()
+    {
+        return self::TEST_APP;
+    }
+
     /**
      * Setup before each test.
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
+        $this->installTestApp();
         parent::setUp();
-
-        $this->updateConfigFile();
-    }
-
-    public function updateConfigFile()
-    {
-        $filledFile = str_replace('Illuminate\View\ViewServiceProvider::class,',
-        'Illuminate\View\ViewServiceProvider::class,
-        /*
-         * Package Service Providers...
-         */', file_get_contents(config_path('app.php')));
-        file_put_contents(config_path('app.php'), $filledFile);
     }
 
     /**
      * Tear down after each test.
      * @return  void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
-        $this->removeDir(base_path('packages'));
-        $this->undoConfigFile();
-
+        $this->uninstallTestApp();
         parent::tearDown();
-    }
-
-    public function undoConfigFile()
-    {
-        $filledFile = str_replace('
-        /*
-         * Package Service Providers...
-         */', '', file_get_contents(config_path('app.php')));
-        file_put_contents(config_path('app.php'), $filledFile);
-
-        $filledFile = str_replace('MyVendor\MyPackage\MyPackageServiceProvider::class,', '', file_get_contents(config_path('app.php')));
-        file_put_contents(config_path('app.php'), $filledFile);
     }
 
     /**
@@ -63,4 +55,5 @@ abstract class TestCase extends TestBench
     {
         return ['JeroenG\Packager\PackagerServiceProvider'];
     }
+
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -3,33 +3,65 @@
 namespace JeroenG\Packager\Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 trait TestHelper
 {
-    public function removeDir($path)
-    {
-        $files = array_diff(scandir($path), ['.', '..']);
-        foreach ($files as $file) {
-            if (is_dir("$path/$file")) {
-                $this->removeDir("$path/$file");
-            } else {
-                @chmod("$path/$file", 0777);
-                @unlink("$path/$file");
-            }
-        }
-
-        return rmdir($path);
-    }
 
     protected function seeInConsoleOutput($expectedText)
     {
         $consoleOutput = $this->app[Kernel::class]->output();
-        $this->assertContains($expectedText, $consoleOutput, "Did not see `{$expectedText}` in console output: `$consoleOutput`");
+        $this->assertStringContainsString($expectedText, $consoleOutput,
+            "Did not see `{$expectedText}` in console output: `$consoleOutput`");
     }
 
     protected function doNotSeeInConsoleOutput($unExpectedText)
     {
         $consoleOutput = $this->app[Kernel::class]->output();
-        $this->assertNotContains($unExpectedText, $consoleOutput, "Did not expect to see `{$unExpectedText}` in console output: `$consoleOutput`");
+        $this->assertStringNotContainsString($unExpectedText, $consoleOutput,
+            "Did not expect to see `{$unExpectedText}` in console output: `$consoleOutput`");
+    }
+
+    /**
+     * Create a modified copy of testbench to be used as a template.
+     * Before each test, a fresh copy of the template is created
+     */
+    private static function setUpLocalTestbench()
+    {
+        fwrite(STDOUT, "Setting up test environment for first use.\n");
+        $files = new Filesystem();
+        $files->makeDirectory(self::TEST_APP_TEMPLATE, 0755, true);
+        $original = __DIR__.'/../vendor/orchestra/testbench-core/laravel/';
+        $files->copyDirectory($original, self::TEST_APP_TEMPLATE);
+        // Modify the composer.json file
+        $composer = json_decode($files->get(self::TEST_APP_TEMPLATE.'/composer.json'), true);
+        // Remove "tests/TestCase.php" from autoload (it doesn't exist)
+        unset($composer['autoload']['classmap'][1]);
+        // Pre-install illuminate/support
+        $composer['require'] = ['illuminate/support' => '~5'];
+        // Install stable version
+        $composer['minimum-stability'] = 'stable';
+        $files->put(self::TEST_APP_TEMPLATE.'/composer.json', json_encode($composer, JSON_PRETTY_PRINT));
+        // Install dependencies
+        fwrite(STDOUT, "Installing test environment dependencies\n");
+        (new Process(['composer', 'install', '--no-dev'], self::TEST_APP_TEMPLATE))->run(function ($type, $buffer) {
+            fwrite(STDOUT, $buffer);
+        });
+    }
+
+    protected function installTestApp()
+    {
+        $this->uninstallTestApp();
+        $files = new Filesystem();
+        $files->copyDirectory(self::TEST_APP_TEMPLATE, self::TEST_APP);
+    }
+
+    protected function uninstallTestApp()
+    {
+        $files = new Filesystem();
+        if ($files->exists(self::TEST_APP)) {
+            $files->deleteDirectory(self::TEST_APP);
+        }
     }
 }


### PR DESCRIPTION
Hi, thanks for an excellent package.

I've made a few changes that I think makes the workflow a bit simpler and more intuitive.
By using path repositories in the parent project, the packages can be installed exactly like any other package.
Here are the benefits as I see them:
- No need to install/update dependencies in the package sub-folders. Everything is managed from the project root.
- Service providers are discovered automatically during installation.
- Classes in the package namespaces are autoloaded automatically just like any other package.
- Having only one `vendor/` folder means no duplicate dependencies, which tend to confuse IDEs like PhpStorm.

Let me know if anything needs to be changed.