### PR TITLE
Add git packages as VCS repositories

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,8 +20,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-html" target="./report" charset="UTF-8"
-            yui="true" highlight="true"
-            lowUpperBound="50" highLowerBound="80" />
+        <log type="coverage-html" target="./report" lowUpperBound="50" highLowerBound="80" />
     </logging>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -66,13 +66,14 @@ $ php artisan packager:git https://github.com/author/repository
 
 **Result:**
 This will register the package in the app's `composer.json` file.
-If the `packager:git` command is used, the entire Git repository is cloned. If `packager:get` is used, the package will be downloaded, without a repository. This also works with Bitbucket repositories, but you have to provide the flag `--host=bitbucket` for the `packager:get` command.
+If the `packager:git` command is used, the entire Git repository is cloned (you can optionally specify the branch/version to clone using the `--branch` option). If `packager:get` is used, the package will be downloaded, without a repository. This also works with Bitbucket repositories, but you have to provide the flag `--host=bitbucket` for the `packager:get` command.
 
 **Options:**
 ```bash
 $ php artisan packager:get https://github.com/author/repository --branch=develop
 $ php artisan packager:get https://github.com/author/repository MyVendor MyPackage
 $ php artisan packager:git https://github.com/author/repository MyVendor MyPackage
+$ php artisan packager:git github-user/github-repo --branch=dev-mybranch
 ```
 It is possible to specify a branch with the `--branch` option. If you specify a vendor and name directly after the url, those will be used instead of the pieces of the url.
 
@@ -142,6 +143,14 @@ You first need to run
 $ composer require sensiolabs/security-checker
 ```
 
+## Managing dependencies
+When you install a new package using `packager:new`, `packager:get` or `packager:git`, the package dependencies will automatically be installed into the parent project's `vendor/` folder.
+
+Installing or updating package dependencies should *not* be done directly from the `packages/` folder.
+
+When you've edited the `composer.json` file in your package folder, you should run `composer update` from the root folder of the parent project. 
+
+If your package was installed using the `packager:git` command, any changes you make to the package's `composer.json` file will not be detected by the parent project until the changes have been committed.
 
 ## Issues with cURL SSL certificate
 It turns out that, especially on Windows, there might arise some problems with the downloading of the skeleton, due to a file regarding SSL certificates missing on the OS. This can be solved by opening up your .env file and putting this in it:

--- a/src/Commands/EnablePackage.php
+++ b/src/Commands/EnablePackage.php
@@ -74,7 +74,7 @@ class EnablePackage extends Command
 
         // Install the package
         $this->info('Installing package...');
-        $this->conveyor->installPackage();
+        $this->conveyor->installPackageFromPath();
         $this->makeProgress();
 
         // Finished removing the package, end of the progress bar

--- a/src/Commands/GetPackage.php
+++ b/src/Commands/GetPackage.php
@@ -109,7 +109,7 @@ class GetPackage extends Command
 
         // Install the package
         $this->info('Installing package...');
-        $this->conveyor->installPackage();
+        $this->conveyor->installPackageFromPath();
         $this->makeProgress();
 
         // Finished creating the package, end of the progress bar

--- a/src/Commands/ListPackages.php
+++ b/src/Commands/ListPackages.php
@@ -35,14 +35,29 @@ class ListPackages extends Command
         $repositories = $composer['repositories'] ?? [];
         $packages = [];
         foreach ($repositories as $name => $info) {
-            $path = $info['url'];
-            $pattern = '{'.addslashes($packages_path).'(.*)$}';
-            if (preg_match($pattern, $path, $match)) {
-                $packages[] = explode(DIRECTORY_SEPARATOR, $match[1]);
+            if ($info['type'] === 'path'){
+                $path = $info['url'];
+                $pattern = '{'.addslashes($packages_path).'(.*)$}';
+                if (preg_match($pattern, $path, $match)) {
+                    $packages[] = [$name, 'packages/'.$match[1]];
+                }
+            }
+            else if ($info['type'] === 'vcs'){
+                $path = $packages_path . $name;
+                if (file_exists($path)){
+                    $pattern = '{'.addslashes($packages_path).'(.*)$}';
+                    if (preg_match($pattern, $path, $match)) {
+                        $packages[] = [$name, 'packages/'.$match[1]];
+                    }
+                }
             }
         }
-
         $headers = ['Package', 'Path'];
         $this->table($headers, $packages);
+    }
+
+    protected function getGitStatus($path)
+    {
+        $command = sprintf('git --work-tree=%s status', realpath($path));
     }
 }

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -135,7 +135,7 @@ class NewPackage extends Command
 
         // Add path repository to composer.json and install package
         $this->info('Installing package...');
-        $this->conveyor->installPackage();
+        $this->conveyor->installPackageFromPath();
 
         $this->makeProgress();
 

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -92,7 +92,7 @@ class Conveyor
     public function installPackageFromPath()
     {
         $this->addComposerRepository();
-        $this->requirePackage();
+        $this->requirePackage(null, false);
     }
 
     public function installPackageFromVcs($url, $version)
@@ -149,7 +149,7 @@ class Conveyor
         ]);
     }
 
-    protected function requirePackage(string $version = null)
+    protected function requirePackage(string $version = null, bool $prefer_source = true)
     {
         $package = $this->getPackageName();
         if ($version !== null) {
@@ -159,7 +159,7 @@ class Conveyor
             'composer',
             'require',
             $package,
-            '--prefer-source'
+            '--prefer-' . ($prefer_source ? 'source' : 'dist'),
         ]);
         if (!$result['success']){
             if (preg_match('/Could not find a matching version of package/', $result['output'])){

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -83,6 +83,10 @@ trait FileHandler
      */
     public function removeDir($path)
     {
+        if (is_link($path)){
+            unlink($path);
+            return true;
+        }
         if ($path == 'packages' || $path == '/') {
             return false;
         }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -11,9 +11,14 @@ trait TestHelper
 
     protected function seeInConsoleOutput($expectedText)
     {
+        if (!is_array($expectedText)){
+            $expectedText = [$expectedText];
+        }
         $consoleOutput = $this->app[Kernel::class]->output();
-        $this->assertStringContainsString($expectedText, $consoleOutput,
-            "Did not see `{$expectedText}` in console output: `$consoleOutput`");
+        foreach ($expectedText as $string) {
+            $this->assertStringContainsString($string, $consoleOutput,
+                "Did not see `{$string}` in console output: `$consoleOutput`");
+        }
     }
 
     protected function doNotSeeInConsoleOutput($unExpectedText)


### PR DESCRIPTION
I've changed the way `packager:git` works.
In stead of cloning the repository directly to the `/packages/myVendor/myPackage` folder, it is added as a VCS repository in `composer.json` and installed like any other package to the `/vendor` folder. After installing, it is symlinked to the `/packages` folder.

If the package origin is only specified as `vendor/package` in stead of a complete URL, it is assumed that the repository is located at `https://github.com/vendor/package`.

The `packager:list` command now has an extra column showing the Git status of the package. If packages are version controlled, it will whether they're `Up to date`, `Ahead {number of commits}` or `Behind {number of commits}`. If not, they're displayed as `Not initialized`.

I've add a couple of tests to ensure the new features are working correctly. They both clone your `Jeroen-G/testassist` repository, but it doesn't really matter which repository they use, if you want to change it to something else.

Let me know if anything needs to be changed.

/Morten