### PR TITLE
Broadening replacements for improved skeleton replacements

### DIFF
--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -3,6 +3,8 @@
 namespace JeroenG\Packager;
 
 use ZipArchive;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use RuntimeException;
 use GuzzleHttp\Client;
 
@@ -156,20 +158,20 @@ trait FileHandler
     public function renameFiles($manifest = null)
     {
         $bindings = [
-            [':uc:vendor', ':uc:package', ':lc:vendor', ':lc:package'],
+            ['MyVendor', 'MyPackage', 'myvendor', 'mypackage'],
             [$this->vendor(), $this->package(), strtolower($this->vendor()), strtolower($this->package())],
         ];
 
-        $rewrites = require ($manifest === null) ? [
-            'src/MyPackage.php' => 'src/:uc:package.php',
-            'config/mypackage.php' => 'config/:lc:package.php',
-            'src/Facades/MyPackage.php' => 'src/Facades/:uc:package.php',
-            'src/MyPackageServiceProvider.php' => 'src/:uc:packageServiceProvider.php',
-        ] : $manifest;
-
-        foreach ($rewrites as $file => $name) {
-            $filename = str_replace($bindings[0], $bindings[1], $name);
-            rename($this->packagePath().'/'.$file, $this->packagePath().'/'.$filename);
+        $files = new RecursiveDirectoryIterator($this->packagePath());
+        foreach(new RecursiveIteratorIterator($files) as $file) {
+            if (!$file->isFile()) {
+                continue;                
+            }
+            $replaced = str_replace($bindings[0], $bindings[1], $file->getFilename());
+            if ($replaced === $file->getFilename()) {
+                continue;
+            }
+            rename($file->getPath().'/'.$file->getFilename(), $file->getPath().'/'.$replaced);
         }
     }
 

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -3,10 +3,10 @@
 namespace JeroenG\Packager;
 
 use ZipArchive;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use RuntimeException;
 use GuzzleHttp\Client;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
 
 trait FileHandler
 {
@@ -163,9 +163,9 @@ trait FileHandler
         ];
 
         $files = new RecursiveDirectoryIterator($this->packagePath());
-        foreach(new RecursiveIteratorIterator($files) as $file) {
-            if (!$file->isFile()) {
-                continue;                
+        foreach (new RecursiveIteratorIterator($files) as $file) {
+            if (! $file->isFile()) {
+                continue;
             }
             $replaced = str_replace($bindings[0], $bindings[1], $file->getFilename());
             if ($replaced === $file->getFilename()) {

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -2,8 +2,8 @@
 
 namespace JeroenG\Packager;
 
-use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
 
 class Wrapping
 {
@@ -51,9 +51,9 @@ class Wrapping
     public function fill($path)
     {
         $files = new RecursiveDirectoryIterator($path);
-        foreach(new RecursiveIteratorIterator($files) as $file) {
-            if (!$file->isFile()) {
-                continue;                
+        foreach (new RecursiveIteratorIterator($files) as $file) {
+            if (! $file->isFile()) {
+                continue;
             }
 
             $this->fillInFile($file->getPath().'/'.$file->getFilename());

--- a/src/Wrapping.php
+++ b/src/Wrapping.php
@@ -2,6 +2,9 @@
 
 namespace JeroenG\Packager;
 
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 class Wrapping
 {
     /**
@@ -47,17 +50,13 @@ class Wrapping
      */
     public function fill($path)
     {
-        $templates = array_merge(
-            glob($path.'/composer.json'),
-            glob($path.'/*.md'),
-            glob($path.'/*.php'),
-            glob($path.'/src/*.php'),
-            glob($path.'/src/Facades/*.php'),
-            glob($path.'/tests/*.php'),
-            glob($path.'/config/*.php')
-        );
-        foreach ($templates as $file) {
-            $this->fillInFile($file);
+        $files = new RecursiveDirectoryIterator($path);
+        foreach(new RecursiveIteratorIterator($files) as $file) {
+            if (!$file->isFile()) {
+                continue;                
+            }
+
+            $this->fillInFile($file->getPath().'/'.$file->getFilename());
         }
     }
 


### PR DESCRIPTION
When I started I thought of adding a second `rewriteRules.php` file for `replaceRules.php`, it seemed like it was a little too cumbersome. 

Instead this approach uses an itterator and searches anything and everything recusively. It's an optimization for convenience which seems quite "Laravel". It's undoubtedly a little slower but the work is done locally and infrequently. 

Since the last pull request removed the string replace method of updating composer -- <3 -- I'm wondering if using Wrapper.php for content S&R is still a good idea. Maybe these dual directory itterators could be combined to improving the speed.

---

In my skeleton I was looking to move  `src\MyPackageProvider` to `src\Providers\MyPackageProvider` while adding a couple other items. 

Where 4n70w4 in #81 , for a Nova version (mirroring novas version) would require replaces in `src/resources/js`.