### PR TITLE
Added ability to change composer.json filename

### DIFF
--- a/config/packager.php
+++ b/config/packager.php
@@ -9,6 +9,12 @@ return [
     'skeleton' => 'http://github.com/Jeroen-G/packager-skeleton/archive/master.zip',
 
     /*
+     * You can change composer.json file name.
+     * It can be useful for projects with composer merge-plugin usage
+     */
+    'composer_json_filename' => 'composer.json',
+
+    /*
      * You can set defaults for the following placeholders.
      */
     'author_name' => 'author name',

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -97,7 +97,10 @@ class Conveyor
 
     public function installPackage()
     {
-        $this->addPathRepository();
+        $this->addPathRepository(
+            config('packager.composer_json_filename')
+        );
+
         $this->requirePackage();
     }
 
@@ -107,19 +110,25 @@ class Conveyor
         $this->removePathRepository();
     }
 
-    public function addPathRepository()
+    /**
+     * @param string $composer_json_filename
+     *
+     * @return bool
+     */
+    public function addPathRepository($composer_json_filename)
     {
         $params = json_encode([
             'type' => 'path',
             'url'  => $this->packagePath(),
         ]);
+
         $command = [
             'composer',
             'config',
             'repositories.'.Str::slug($this->vendor.'-'.$this->package),
             $params,
             '--file',
-            'composer.json',
+            $composer_json_filename,
         ];
 
         return $this->runProcess($command);

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -98,7 +98,7 @@ class Conveyor
     public function installPackage()
     {
         $this->addPathRepository(
-            config('packager.composer_json_filename')
+            config('packager.composer_json_filename', 'composer.json')
         );
 
         $this->requirePackage();


### PR DESCRIPTION
We are using [composer merge plugin](https://github.com/wikimedia/composer-merge-plugin) and store local repositories and dependencies )(for package development) into `composer.dev.json`.

This patch will add ability to change the `composer.json` filename via config.