### PR TITLE
Get CURL_VERIFY param from config() instead of env()

### DIFF
--- a/config/packager.php
+++ b/config/packager.php
@@ -8,6 +8,8 @@ return [
      */
     'skeleton' => 'http://github.com/Jeroen-G/packager-skeleton/archive/master.zip',
 
+    'curl_verify_cert' => env('CURL_VERIFY', true),
+
     /*
      * You can set defaults for the following placeholders.
      */

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -109,7 +109,7 @@ trait FileHandler
      */
     public function download($zipFile, $source)
     {
-        $client = new Client(['verify' => env('CURL_VERIFY', true)]);
+        $client = new Client(['verify' => config('packager.curl_verify_cert', true)]);
         $response = $client->get($source);
         file_put_contents($zipFile, $response->getBody());
 


### PR DESCRIPTION
When Laravel configs are cached (`php artisan config:cache`), any env(..) calls will return `null` instead of correct value.

Reference: https://stackoverflow.com/a/53385384