### PR TITLE
Added ability to use tar and tar.gz or any other skeleton archive format

### DIFF
--- a/src/ArchiveExtractors/Extractor.php
+++ b/src/ArchiveExtractors/Extractor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JeroenG\Packager\ArchiveExtractors;
+
+abstract class Extractor
+{
+    /**
+     * @param string $pathToArchive
+     * @param string $pathToDirectory
+     *
+     * @return void
+     */
+    abstract function extract($pathToArchive, $pathToDirectory);
+}

--- a/src/ArchiveExtractors/Extractor.php
+++ b/src/ArchiveExtractors/Extractor.php
@@ -10,5 +10,5 @@ abstract class Extractor
      *
      * @return void
      */
-    abstract public function extract($pathToArchive, $pathToDirectory);
+    abstract public function extract(string $pathToArchive, string $pathToDirectory): void;
 }

--- a/src/ArchiveExtractors/Extractor.php
+++ b/src/ArchiveExtractors/Extractor.php
@@ -10,5 +10,5 @@ abstract class Extractor
      *
      * @return void
      */
-    abstract function extract($pathToArchive, $pathToDirectory);
+    abstract public function extract($pathToArchive, $pathToDirectory);
 }

--- a/src/ArchiveExtractors/Manager.php
+++ b/src/ArchiveExtractors/Manager.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection ALL */
 
 namespace JeroenG\Packager\ArchiveExtractors;
 
@@ -10,18 +10,25 @@ final class Manager
     /** @var Extractor[] */
     protected $extractorsMap = [];
 
+    public function __construct()
+    {
+        $this->addExtractor('zip', new Zip())
+             ->addExtractor('tar', new Tar())
+             ->addExtractor('tar.gz', new TarGz());
+    }
+
     /**
      * @param string $archiveExtension
      *
      * @return Extractor
      * @throws InvalidArgumentException
      */
-    public function getExtractor($archiveExtension)
+    public function getExtractor(string $archiveExtension): Extractor
     {
         $extractor = Arr::get($this->extractorsMap, $archiveExtension);
 
-        if (! $extractor) {
-            throw new InvalidArgumentException("There is no extractors for extension '{$archiveExtension}'!");
+        if (!$extractor) {
+            throw new InvalidArgumentException("There are no extractors for extension '{$archiveExtension}'!");
         }
 
         return $extractor;
@@ -33,7 +40,7 @@ final class Manager
      *
      * @return self
      */
-    public function extend($archiveExtension, Extractor $instance)
+    public function addExtractor(string $archiveExtension, Extractor $instance): self
     {
         $this->extractorsMap[$archiveExtension] = $instance;
 

--- a/src/ArchiveExtractors/Manager.php
+++ b/src/ArchiveExtractors/Manager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace JeroenG\Packager\ArchiveExtractors;
+
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+final class Manager
+{
+    /** @var Extractor[] */
+    protected $extractorsMap = [];
+
+    /**
+     * @param string $archiveExtension
+     *
+     * @return Extractor
+     * @throws InvalidArgumentException
+     */
+    public function getExtractor($archiveExtension)
+    {
+        $extractor = Arr::get($this->extractorsMap, $archiveExtension);
+
+        if (!$extractor) {
+            throw new InvalidArgumentException("There is no extractors for extension '{$archiveExtension}'!");
+        }
+
+        return $extractor;
+    }
+
+    /**
+     * @param string $archiveExtension
+     * @param Extractor $instance
+     *
+     * @return self
+     */
+    public function extend($archiveExtension, Extractor $instance)
+    {
+        $this->extractorsMap[$archiveExtension] = $instance;
+
+        return $this;
+    }
+}

--- a/src/ArchiveExtractors/Manager.php
+++ b/src/ArchiveExtractors/Manager.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection ALL */
+<?php
 
 namespace JeroenG\Packager\ArchiveExtractors;
 
@@ -27,7 +27,7 @@ final class Manager
     {
         $extractor = Arr::get($this->extractorsMap, $archiveExtension);
 
-        if (!$extractor) {
+        if (! $extractor) {
             throw new InvalidArgumentException("There are no extractors for extension '{$archiveExtension}'!");
         }
 

--- a/src/ArchiveExtractors/Manager.php
+++ b/src/ArchiveExtractors/Manager.php
@@ -20,7 +20,7 @@ final class Manager
     {
         $extractor = Arr::get($this->extractorsMap, $archiveExtension);
 
-        if (!$extractor) {
+        if (! $extractor) {
             throw new InvalidArgumentException("There is no extractors for extension '{$archiveExtension}'!");
         }
 

--- a/src/ArchiveExtractors/Tar.php
+++ b/src/ArchiveExtractors/Tar.php
@@ -7,9 +7,9 @@ use PharData;
 class Tar extends Extractor
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    function extract($pathToArchive, $pathToDirectory)
+    public function extract($pathToArchive, $pathToDirectory)
     {
         $phar = new PharData($pathToArchive);
         $phar->extractTo($pathToDirectory);

--- a/src/ArchiveExtractors/Tar.php
+++ b/src/ArchiveExtractors/Tar.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JeroenG\Packager\ArchiveExtractors;
+
+use PharData;
+
+class Tar extends Extractor
+{
+    /**
+     * @inheritDoc
+     */
+    function extract($pathToArchive, $pathToDirectory)
+    {
+        $phar = new PharData($pathToArchive);
+        $phar->extractTo($pathToDirectory);
+    }
+}

--- a/src/ArchiveExtractors/Tar.php
+++ b/src/ArchiveExtractors/Tar.php
@@ -9,9 +9,9 @@ class Tar extends Extractor
     /**
      * {@inheritdoc}
      */
-    public function extract($pathToArchive, $pathToDirectory)
+    public function extract(string $pathToArchive, string $pathToDirectory): void
     {
-        $phar = new PharData($pathToArchive);
-        $phar->extractTo($pathToDirectory);
+        $archive = new PharData($pathToArchive);
+        $archive->extractTo($pathToDirectory);
     }
 }

--- a/src/ArchiveExtractors/TarGz.php
+++ b/src/ArchiveExtractors/TarGz.php
@@ -7,9 +7,9 @@ use PharData;
 class TarGz extends Extractor
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    function extract($pathToArchive, $pathToDirectory)
+    public function extract($pathToArchive, $pathToDirectory)
     {
         $phar = new PharData($pathToArchive);
         $phar->decompress();

--- a/src/ArchiveExtractors/TarGz.php
+++ b/src/ArchiveExtractors/TarGz.php
@@ -9,17 +9,27 @@ class TarGz extends Extractor
     /**
      * {@inheritdoc}
      */
-    public function extract($pathToArchive, $pathToDirectory)
+    public function extract(string $pathToArchive, string $pathToDirectory): void
+    {
+        $pathToTarArchive = $this->extractTarPathFromGz($pathToArchive);
+        $archive = new PharData($pathToTarArchive);
+        $archive->extractTo($pathToDirectory);
+
+        unlink($pathToTarArchive);
+    }
+
+    /**
+     * Get the path to the tar within the gz folder.
+     *
+     * @param string $pathToArchive
+     * @return string
+     */
+    private function extractTarPathFromGz(string $pathToArchive): string
     {
         $phar = new PharData($pathToArchive);
         $phar->decompress();
 
-        // Remove .gz
-        $pathToTarArchive = str_replace('.gz', '', $pathToArchive);
-
-        $phar = new PharData($pathToTarArchive);
-        $phar->extractTo($pathToDirectory);
-
-        unlink($pathToTarArchive);
+        // Remove .gz and return path.
+        return str_replace('.gz', '', $pathToArchive);
     }
 }

--- a/src/ArchiveExtractors/TarGz.php
+++ b/src/ArchiveExtractors/TarGz.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JeroenG\Packager\ArchiveExtractors;
+
+use PharData;
+
+class TarGz extends Extractor
+{
+    /**
+     * @inheritDoc
+     */
+    function extract($pathToArchive, $pathToDirectory)
+    {
+        $phar = new PharData($pathToArchive);
+        $phar->decompress();
+
+        // Remove .gz
+        $pathToTarArchive = str_replace('.gz', '', $pathToArchive);
+
+        $phar = new PharData($pathToTarArchive);
+        $phar->extractTo($pathToDirectory);
+
+        unlink($pathToTarArchive);
+    }
+}

--- a/src/ArchiveExtractors/Zip.php
+++ b/src/ArchiveExtractors/Zip.php
@@ -9,7 +9,7 @@ class Zip extends Extractor
     /**
      * {@inheritdoc}
      */
-    public function extract($pathToArchive, $pathToDirectory)
+    public function extract(string $pathToArchive, string $pathToDirectory): void
     {
         $archive = new ZipArchive;
         $archive->open($pathToArchive);

--- a/src/ArchiveExtractors/Zip.php
+++ b/src/ArchiveExtractors/Zip.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace JeroenG\Packager\ArchiveExtractors;
+
+use ZipArchive;
+
+class Zip extends Extractor
+{
+    /**
+     * @inheritDoc
+     */
+    function extract($pathToArchive, $pathToDirectory)
+    {
+        $archive = new ZipArchive;
+        $archive->open($pathToArchive);
+        $archive->extractTo($pathToDirectory);
+        $archive->close();
+    }
+}

--- a/src/ArchiveExtractors/Zip.php
+++ b/src/ArchiveExtractors/Zip.php
@@ -7,9 +7,9 @@ use ZipArchive;
 class Zip extends Extractor
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    function extract($pathToArchive, $pathToDirectory)
+    public function extract($pathToArchive, $pathToDirectory)
     {
         $archive = new ZipArchive;
         $archive->open($pathToArchive);

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -2,8 +2,8 @@
 
 namespace JeroenG\Packager;
 
-use RuntimeException;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class Conveyor
 {
@@ -84,8 +84,12 @@ class Conveyor
         $directoryToMove = $tempDir;
 
         // 3 because '.', '..', and one file or directory
-        if (count($tempDirFilesList) === 3 && is_dir($realSkeletonDir = $tempDir . '/' . $tempDirFilesList[2])) {
-            $directoryToMove = $realSkeletonDir;
+        if (count($tempDirFilesList) === 3) {
+            $maybeRealSkeletonDir = $tempDir.'/'.$tempDirFilesList[2];
+
+            if (is_dir($maybeRealSkeletonDir)) {
+                $directoryToMove = $maybeRealSkeletonDir;
+            }
         }
 
         rename($directoryToMove, $this->packagePath());

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -66,37 +66,19 @@ class Conveyor
      */
     public function downloadSkeleton()
     {
-        $archiveUrl = config('packager.skeleton');
-        $extension = $this->getArchiveExtension($archiveUrl);
+        $skeletonArchiveUrl = config('packager.skeleton');
+        $extension = $this->getArchiveExtension($skeletonArchiveUrl);
 
-        $tempDir = $this->tempPath().'/'.uniqid();
-
-        $this->download($archive = $this->makeFilename($extension), $archiveUrl)
-            ->extract($archive, $tempDir)
+        $this->download($archive = $this->makeFilename($extension), $skeletonArchiveUrl)
+            ->extract($archive, $this->tempPath())
             ->cleanUp($archive);
 
-        // Before move files to vendor/package folder, ensure that we have non-wrapped skeleton.
-        // There are two options:
-        // 1. Many files in archive root
-        // 2. Single folder with files in archive root
-        $tempDirFilesList = scandir($tempDir);
+        $firstInDirectory = scandir($this->tempPath())[2];
+        $extractedSkeletonLocation = $this->tempPath().'/'.$firstInDirectory;
+        rename($extractedSkeletonLocation, $this->packagePath());
 
-        $directoryToMove = $tempDir;
-
-        // 3 because '.', '..', and one file or directory
-        if (count($tempDirFilesList) === 3) {
-            $maybeRealSkeletonDir = $tempDir.'/'.$tempDirFilesList[2];
-
-            if (is_dir($maybeRealSkeletonDir)) {
-                $directoryToMove = $maybeRealSkeletonDir;
-            }
-        }
-
-        rename($directoryToMove, $this->packagePath());
-
-        // Delete temp dir if exists
-        if (is_dir($tempDir)) {
-            rmdir($tempDir);
+        if (is_dir($this->tempPath())) {
+            rmdir($this->tempPath());
         }
     }
 

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -2,12 +2,12 @@
 
 namespace JeroenG\Packager;
 
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
 use JeroenG\Packager\ArchiveExtractors\Manager;
 use JeroenG\Packager\ArchiveExtractors\Zip;
 use RuntimeException;
-use GuzzleHttp\Client;
 
 trait FileHandler
 {
@@ -38,10 +38,10 @@ trait FileHandler
      */
     public function tempPath()
     {
-        $path = $this->packagesPath() . '/temp';
+        $path = $this->packagesPath().'/temp';
 
         // Ensure that temp dir exists
-        if (!is_dir($path)) {
+        if (! is_dir($path)) {
             mkdir($path);
         }
 
@@ -149,8 +149,8 @@ trait FileHandler
     {
         $extension = $this->getArchiveExtension($archiveFilePath);
 
-        /** @var Manager $extractorManager */
         try {
+            /** @var Manager $extractorManager */
             $extractorManager = app()->make(Manager::class);
             $extractor = $extractorManager->getExtractor($extension);
         } catch (BindingResolutionException $e) {
@@ -231,7 +231,7 @@ trait FileHandler
             if ($childExtension = pathinfo($pathParts['filename'], PATHINFO_EXTENSION)) {
                 $extension = implode('.', [
                     $childExtension,
-                    $extension
+                    $extension,
                 ]);
             }
         }

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -228,7 +228,9 @@ trait FileHandler
         // Hack for complex file extensions
         if (in_array($extension, ['gz', 'xz'])) {
             // Check child extension
-            if ($childExtension = pathinfo($pathParts['filename'], PATHINFO_EXTENSION)) {
+            $childExtension = pathinfo($pathParts['filename'], PATHINFO_EXTENSION);
+
+            if ($childExtension) {
                 $extension = implode('.', [
                     $childExtension,
                     $extension,

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -3,10 +3,7 @@
 namespace JeroenG\Packager;
 
 use GuzzleHttp\Client;
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Log;
 use JeroenG\Packager\ArchiveExtractors\Manager;
-use JeroenG\Packager\ArchiveExtractors\Zip;
 use RuntimeException;
 
 trait FileHandler

--- a/src/PackagerServiceProvider.php
+++ b/src/PackagerServiceProvider.php
@@ -4,10 +4,6 @@ namespace JeroenG\Packager;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
-use JeroenG\Packager\ArchiveExtractors\Manager as ExtractorManager;
-use JeroenG\Packager\ArchiveExtractors\Tar;
-use JeroenG\Packager\ArchiveExtractors\TarGz;
-use JeroenG\Packager\ArchiveExtractors\Zip;
 
 /**
  * This is the service provider.
@@ -46,18 +42,6 @@ class PackagerServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/packager.php' => config_path('packager.php'),
         ]);
-
-        // Register ExtractorManager singleton
-        $this->app->singleton(ExtractorManager::class, function () {
-            return new ExtractorManager();
-        });
-
-        /** @var ExtractorManager $manager */
-        $manager = $this->app->make(ExtractorManager::class);
-
-        $manager->extend('zip', new Zip())
-            ->extend('tar', new Tar())
-            ->extend('tar.gz', new TarGz());
     }
 
     /**

--- a/src/PackagerServiceProvider.php
+++ b/src/PackagerServiceProvider.php
@@ -47,7 +47,7 @@ class PackagerServiceProvider extends ServiceProvider
             __DIR__.'/../config/packager.php' => config_path('packager.php'),
         ]);
 
-        // Define
+        // Register ExtractorManager singleton
         $this->app->singleton(ExtractorManager::class, function () {
             return new ExtractorManager();
         });

--- a/src/PackagerServiceProvider.php
+++ b/src/PackagerServiceProvider.php
@@ -2,7 +2,12 @@
 
 namespace JeroenG\Packager;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
+use JeroenG\Packager\ArchiveExtractors\Manager as ExtractorManager;
+use JeroenG\Packager\ArchiveExtractors\Tar;
+use JeroenG\Packager\ArchiveExtractors\TarGz;
+use JeroenG\Packager\ArchiveExtractors\Zip;
 
 /**
  * This is the service provider.
@@ -34,12 +39,25 @@ class PackagerServiceProvider extends ServiceProvider
 
     /**
      * Bootstrap the application events.
+     * @throws BindingResolutionException
      */
     public function boot()
     {
         $this->publishes([
             __DIR__.'/../config/packager.php' => config_path('packager.php'),
         ]);
+
+        // Define
+        $this->app->singleton(ExtractorManager::class, function () {
+            return new ExtractorManager();
+        });
+
+        /** @var ExtractorManager $manager */
+        $manager = $this->app->make(ExtractorManager::class);
+
+        $manager->extend('zip', new Zip())
+            ->extend('tar', new Tar())
+            ->extend('tar.gz', new TarGz());
     }
 
     /**

--- a/tests/SkeletonArchiveExtractorsTest.php
+++ b/tests/SkeletonArchiveExtractorsTest.php
@@ -5,7 +5,7 @@ namespace JeroenG\Packager\Tests;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Facades\Artisan;
 
-class TestTarGzSkeletonArchive extends TestCase
+class SkeletonArchiveExtractorsTest extends TestCase
 {
     public function test_new_package_is_created_with_tar_gz_skeleton()
     {

--- a/tests/TestTarGzSkeletonArchive.php
+++ b/tests/TestTarGzSkeletonArchive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JeroenG\Packager\Tests;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Artisan;
+
+class TestTarGzSkeletonArchive extends TestCase
+{
+    public function test_new_package_is_created_with_tar_gz_skeleton()
+    {
+        Artisan::call('packager:new', ['vendor' => 'MyVendor', 'name' => 'MyPackage']);
+
+        $this->seeInConsoleOutput('Package created successfully!');
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        /** @var Repository $config */
+        $config = $app['config'];
+
+        // Change the extension in github archive url form .zip to .tar.gz
+        $originalZipUrl = $config->get('packager.skeleton');
+        $tarGzUrl = str_replace('.zip', '.tar.gz', $originalZipUrl);
+
+        $config->set('packager.skeleton', $tarGzUrl);
+    }
+}


### PR DESCRIPTION
- Added `tar` and `tar.gz` skeleton archive support
- Allow to use archives with non-wrapped files (removed hardcoded `packager-skeleton-master` directory)
- Added ability to add custom archive extractors via extractors Manager.

#91  