### PR TITLE
Added skeleton flag to new command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,10 @@ $ php artisan packager:new --i
 The package will be created interactively, allowing to configure everything in the package's `composer.json`, such as the license and package description.
 
 **Remarks:**
-The new package will be based on [this custom skeleton](https://github.com/jeroen-g/packager-skeleton).
+The new package will be based on [this custom skeleton](https://github.com/jeroen-g/packager-skeleton). If you want to use a different package skeleton, you can either:
+- (A) publish the configuration file using ```php artisan vendor:publish --provider="JeroenG\Packager\PackagerServiceProvider"``` and change the default skeleton that will be used by all ```php artisan packager:new``` calls;
+- (B) attach a ```--skeleton="http://github.com/path/to/arhive/master.zip"``` to your call, to forcefully use the given skeleton for this one call, instead of the one in the config file;
+
 
 ### Get & Git
 **Command:**

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -20,7 +20,7 @@ class NewPackage extends Command
      * The name and signature of the console command.
      * @var string
      */
-    protected $signature = 'packager:new {vendor} {name} {--i}';
+    protected $signature = 'packager:new {vendor} {name} {--i} {--skeleton=}';
 
     /**
      * The console command description.
@@ -88,7 +88,11 @@ class NewPackage extends Command
 
         // Get the packager package skeleton
         $this->info('Downloading skeleton...');
-        $this->conveyor->downloadSkeleton();
+        if ($this->option('i')) {
+            $this->conveyor->downloadSkeleton($this->ask('What package skeleton would you like to use?', $this->option('skeleton') ?? config('packager.skeleton')));
+        } else {
+            $this->conveyor->downloadSkeleton($this->option('skeleton') ?? null);
+        }
         $manifest = (file_exists($this->conveyor->packagePath().'/rewriteRules.php')) ? $this->conveyor->packagePath().'/rewriteRules.php' : null;
         $this->conveyor->renameFiles($manifest);
         $this->makeProgress();

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -64,9 +64,9 @@ class Conveyor
     /**
      * Download the skeleton package.
      */
-    public function downloadSkeleton()
+    public function downloadSkeleton($skeletonArchiveUrl = null)
     {
-        $skeletonArchiveUrl = config('packager.skeleton');
+        $skeletonArchiveUrl = $skeletonArchiveUrl ?? config('packager.skeleton');
         $extension = $this->getArchiveExtension($skeletonArchiveUrl);
 
         $this->download($archive = $this->makeFilename($extension), $skeletonArchiveUrl)

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -25,9 +25,9 @@ class IntegratedTest extends TestCase
     public function test_new_package_is_installed_from_custom_skeleton()
     {
         Artisan::call('packager:new', [
-            'vendor' => 'AnotherVendor', 
+            'vendor' => 'AnotherVendor',
             'name' => 'AnotherPackage',
-            '--skeleton' => 'http://github.com/Jeroen-G/packager-skeleton/archive/master.zip'
+            '--skeleton' => 'http://github.com/Jeroen-G/packager-skeleton/archive/master.zip',
         ]);
 
         $composer = file_get_contents(base_path('composer.json'));

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -22,6 +22,19 @@ class IntegratedTest extends TestCase
         $this->assertStringContainsString('MyVendor/MyPackage', $composer);
     }
 
+    public function test_new_package_is_installed_from_custom_skeleton()
+    {
+        Artisan::call('packager:new', [
+            'vendor' => 'AnotherVendor', 
+            'name' => 'AnotherPackage',
+            '--skeleton' => 'http://github.com/Jeroen-G/packager-skeleton/archive/master.zip'
+        ]);
+
+        $composer = file_get_contents(base_path('composer.json'));
+
+        $this->assertStringContainsString('AnotherVendor/AnotherPackage', $composer);
+    }
+
     public function test_get_existing_package()
     {
         Artisan::call('packager:get',


### PR DESCRIPTION
Fixes #104 . Non-breaking change.

Adds an optional ```--skeleton``` flag to the ```new``` command, so that the user can force a certain skeleton to be used, instead of the one in the config file.

Use cases:

```bash
php artisan packager:new MyVendor MyPackage
# RESULT: works exactly like before; uses the skeleton in the config file;

php artisan packager:new MyVendor MyPackage --i
# RESULT: will ask for the skeleton (defaults to the one in the config file)

php artisan packager:new MyVendor MyPackage --skeleton="https://github.com/DigitallyHappy/backpack-operation-skeleton/archive/master.zip"
# RESULT: will download the given skeleton

php artisan packager:new MyVendor MyPackage --i --skeleton="https://github.com/DigitallyHappy/backpack-operation-skeleton/archive/master.zip"
# RESULT: will ask for the skeleton (defaults to the given skeleton, not the one from config)
```

One thing I'm not 100% happy with - the unit test doesn't _actually_ test that it's using a _different_ Skeleton. Because I assume you want a skeleton that _you_ own in the tests. In order to better test this, you'd need to either:
- (A) keep a different skeleton repo, just for this purpose;
- (B) create a branch on https://github.com/Jeroen-G/packager-skeleton - for this purpose;

In both cases, you'd need to _not_ delete that repo/branch, otherwise this test will fail. Which is... a little odd to have one package's test depending on another package. Let me know if the current test will do, or if you want to do A/B, @Jeroen-G .

Other than that, I believe I've covered all use cases. Let me know if you want me to edit this in any way.

Cheers!