### PR TITLE
get and git with any hosting solution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 All Notable changes to Packager will be documented in this file.
 
+## Version 2.6
+
+### Updated
+- `packager:get` and `packager:git` can now use other hosting solutions, including personal hosting
+- `packager:get` and `packager:git` can get source url from packagist
+- packages folder path is configurable
+
+### Fixed
+- run process timeout set to 300 (avoid long composer require timeout error)
+- progress bar buffering
+
 ## Version 2.5
 
 ### Added

--- a/config/packager.php
+++ b/config/packager.php
@@ -1,6 +1,10 @@
 <?php
 
 return [
+    /*
+     * You can set the default packages folder path.
+     */
+    'packages_path' => env('PACKAGES_PATH', base_path('packages')),
 
     /*
      * The following skeleton will be downloaded for each new package.
@@ -23,4 +27,12 @@ return [
     'author_email' => 'author email',
     'author_homepage' => 'author homepage',
     'license' => 'license',
+
+    /*
+     * For other public repositories. Enter the host and the associated url template
+     * to allow zip files to be downloaded.
+     */
+    'repositories' => [
+        //'personal.repo.com' => 'https://:host/:vendor/:name/archive/:branch.zip',
+    ]
 ];

--- a/contributing.md
+++ b/contributing.md
@@ -17,7 +17,7 @@ If you want to contribute but do not know where to start, this list provides som
 
 - **Add tests!** - Your patch likely won't be accepted if it doesn't have tests.
 
-- **Document any change in behaviour** - Make sure the `readme.md`, `changlog.md` and any other relevant documentation are kept up-to-date.
+- **Document any change in behaviour** - Make sure the `readme.md`, `changelog.md` and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 

--- a/readme.md
+++ b/readme.md
@@ -67,21 +67,34 @@ The new package will be based on [this custom skeleton](https://github.com/jeroe
 ### Get & Git
 **Command:**
 ``` bash
+$ php artisan packager:get author/repository
+$ php artisan packager:git author/repository
 $ php artisan packager:get https://github.com/author/repository
 $ php artisan packager:git https://github.com/author/repository
 ```
 
+If you specify only the package name to get, `packager:get` and `packager:git` will ask packagist API to get the repository URL.
+
+If you specify the full URL instead of the package name, it will be directly used as the repository URL.
+This can be useful to get repository content from your personal hosting. To work with `packager:get`, you have to declare 
+the url template associated with your personal hosting domain in the configuration file to allow zip file download, 
+`packager:git` is not impacted.
+
 **Result:**
 This will register the package in the app's `composer.json` file.
-If the `packager:git` command is used, the entire Git repository is cloned. If `packager:get` is used, the package will be downloaded, without a repository. This also works with Bitbucket repositories, but you have to provide the flag `--host=bitbucket` for the `packager:get` command.
+If the `packager:git` command is used, the entire Git repository is cloned. If `packager:get` is used, the package will be downloaded, without a repository.
 
 **Options:**
+
 ```bash
-$ php artisan packager:get https://github.com/author/repository --branch=develop
+$ php artisan packager:git author/repository --branch=develop
 $ php artisan packager:get https://github.com/author/repository MyVendor MyPackage
 $ php artisan packager:git https://github.com/author/repository MyVendor MyPackage
 ```
-It is possible to specify a branch with the `--branch` option. If you specify a vendor and name directly after the url, those will be used instead of the pieces of the url.
+
+It is possible to specify a branch with the `--branch` option. 
+
+If you specify a vendor and name directly after the url, those will be used instead of the pieces of the url.
 
 ### Tests
 **Command:**
@@ -191,4 +204,4 @@ The EU Public License. Please see [license.md](license.md) for more information.
 [link-travis]: https://travis-ci.org/Jeroen-G/laravel-packager
 [link-styleci]: https://styleci.io/repos/37218114
 [link-author]: https://github.com/Jeroen-G
-[link-contributors]: ../../contributors]
+[link-contributors]: ../../contributors

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -4,6 +4,7 @@ namespace JeroenG\Packager;
 
 use Illuminate\Support\Str;
 use RuntimeException;
+use Symfony\Component\Process\Process;
 
 class Conveyor
 {
@@ -85,16 +86,16 @@ class Conveyor
     /**
      * Download the package from Github.
      *
-     * @param string $origin The Github URL
+     * @param PackageRepository $packageRepository Parsed URL
      * @param string $branch The branch to download
      */
-    public function downloadFromGithub($origin, $piece, $branch)
+    public function downloadZipFile(PackageRepository $packageRepository, $branch)
     {
-        $this->download($zipFile = $this->makeFilename(), $origin)
+        $this->download($zipFile = $this->makeFilename(), $packageRepository->getZipUrl($branch))
             ->extract($zipFile, $this->vendorPath())
             ->cleanUp($zipFile);
 
-        rename($this->vendorPath().'/'.$piece.'-'.$branch, $this->packagePath());
+        rename($this->vendorPath().'/'.$packageRepository->name.'-'.$branch, $this->packagePath());
     }
 
     /**
@@ -168,7 +169,8 @@ class Conveyor
      */
     protected function runProcess(array $command)
     {
-        $process = new \Symfony\Component\Process\Process($command, base_path());
+        $process = new Process($command, base_path());
+        $process->setTimeout(300);
         $process->run();
 
         return $process->getExitCode() === 0;

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -15,7 +15,7 @@ trait FileHandler
      */
     public function packagesPath()
     {
-        return base_path('packages');
+        return config('packager.packages_path');
     }
 
     /**

--- a/src/PackageRepository.php
+++ b/src/PackageRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace JeroenG\Packager;
+
+use GuzzleHttp\Client;
+use RuntimeException;
+
+class PackageRepository
+{
+    public $origin;
+    public $host;
+    public $vendor;
+    public $name;
+
+    public function parse($url)
+    {
+        $this->origin = $url;
+
+        // get package url from Packagist API
+        if (preg_match('`^([^/]*)/([^/]*)$`', $url, $m)) {
+            $client = new Client(['verify' => config('packager.curl_verify_cert')]);
+            try {
+                $response = $client->get(sprintf('https://packagist.org/packages/%s/%s.json', $m[1], $m[2]));
+                $json = json_decode($response->getBody()->getContents());
+                $this->origin = $json->package->repository;
+            } catch (GuzzleHttp\Exception\ClientException $e) {
+                throw new RuntimeException('Package not found on packagist');
+            }
+        }
+
+        // parse url
+        $regex = [
+            '`^https?://([^/]*)/([^/]*)/([^./]*).*$`',
+            '`^git@([^:]*):([^/]*)/([^.]*)\.git$`'
+        ];
+
+        foreach ($regex as $rx) {
+            if (preg_match($rx, $this->origin, $m)) {
+                $this->host = $m[1];
+                $this->vendor = $m[2];
+                $this->name = $m[3];
+                return $this;
+            }
+        }
+
+        throw new RuntimeException('Unable to parse URL');
+    }
+
+    public function getZipUrl($branch)
+    {
+        if ($this->host === null) {
+            throw new RuntimeException('You have to parse an URL');
+        }
+
+        // default hosts url templates
+        $urls = [
+            'github.com'    => 'https://:host/:vendor/:name/archive/:branch.zip',
+            'gitlab.com'    => 'https://:host/:vendor/:name/-/archive/:branch/:name-:branch.zip',
+            'bitbucket.org' => 'https://:host/:vendor/:name/get/:branch.zip',
+        ];
+
+        // merge with additionnal hosts
+        $urls = array_merge($urls, config('packager.repositories'));
+
+        if (!isset($urls[$this->host])) {
+            throw new RuntimeException('Unknown repository host');
+        }
+
+        $args = [':host' => $this->host, ':vendor' => $this->vendor, ':name' => $this->name, ':branch' => $branch];
+
+        return str_replace(array_keys($args), array_values($args), $urls[$this->host]);
+    }
+}

--- a/src/PackageRepository.php
+++ b/src/PackageRepository.php
@@ -17,7 +17,7 @@ class PackageRepository
         $this->origin = $url;
 
         // get package url from Packagist API
-        if (preg_match('`^([^/]*)/([^/]*)$`', $url, $m)) {
+        if (preg_match('`^([^/:@]*)/([^/\.]*)$`', $url, $m)) {
             $client = new Client(['verify' => config('packager.curl_verify_cert')]);
             try {
                 $response = $client->get(sprintf('https://packagist.org/packages/%s/%s.json', $m[1], $m[2]));
@@ -46,7 +46,7 @@ class PackageRepository
         throw new RuntimeException('Unable to parse URL');
     }
 
-    public function getZipUrl($branch)
+    public function getZipUrl($branch = 'master')
     {
         if ($this->host === null) {
             throw new RuntimeException('You have to parse an URL');

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -44,6 +44,7 @@ trait ProgressBar
      */
     public function makeProgress()
     {
+        usleep(250 * 1000); // fix display buffering on slow computers
         $this->bar->advance();
     }
 

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -41,6 +41,10 @@ class IntegratedTest extends TestCase
             ['url' => 'https://github.com/Jeroen-G/packager-skeleton', 'vendor' => 'MyVendor', 'name' => 'MyPackage']);
 
         $this->seeInConsoleOutput('Package downloaded successfully!');
+
+        Artisan::call('packager:get', ['url' => 'jeroen-g/laravel-packager']);
+
+        $this->seeInConsoleOutput('Package downloaded successfully!');
     }
 
     public function test_list_packages()

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -3,9 +3,46 @@
 namespace JeroenG\Packager\Tests;
 
 use Illuminate\Support\Facades\Artisan;
+use JeroenG\Packager\PackageRepository;
 
 class IntegratedTest extends TestCase
 {
+    public function test_url_parser()
+    {
+        $parser = new PackageRepository();
+
+        $url = $parser->parse('jeroen-g/laravel-packager')->getZipUrl();
+        $this->assertEquals('https://github.com/Jeroen-G/laravel-packager/archive/master.zip', $url);
+
+        $expected = 'https://github.com/author/package/archive/dev.zip';
+        $url = $parser->parse('https://github.com/author/package')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+        $url = $parser->parse('git@github.com:author/package.git')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+
+        $expected = 'https://gitlab.com/author/package/-/archive/dev/package-dev.zip';
+        $url = $parser->parse('https://gitlab.com/author/package')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+        $url = $parser->parse('git@gitlab.com:author/package.git')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+
+        $expected = 'https://bitbucket.org/author/package/get/dev.zip';
+        $url = $parser->parse('https://bitbucket.org/author/package')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+        $url = $parser->parse('git@bitbucket.org:author/package.git')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+
+        $this->app['config']->set('packager.repositories', [
+            'my.repo.com' => 'https://:host/:vendor/:name/:branch.zip'
+        ]);
+
+        $expected = 'https://my.repo.com/author/package/dev.zip';
+        $url = $parser->parse('https://my.repo.com/author/package')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+        $url = $parser->parse('git@my.repo.com:author/package.git')->getZipUrl('dev');
+        $this->assertEquals($expected, $url);
+    }
+
     public function test_new_package_is_created()
     {
         Artisan::call('packager:new', ['vendor' => 'MyVendor', 'name' => 'MyPackage']);


### PR DESCRIPTION
Hi! I just discover your package today, very interesting!

I modified `packager:get` and `packager:git` to be more flexible. 

In other words, I created a class that will parse the source url via regular expressions and allow to use more git repository hosting solutions (including personal hosting). So it is therefore no longer necessary to specify whether you want to use github or bitbucket.

As a bonus, I added the recovery of the source url via the packagist api, it is now possible to do `packager:get jeroen-g/laravel-package`.

Hope you'll enjoy my contribution.

### How it works :

See the file: [PackageRepository.php](https://github.com/sebastienheyd/laravel-packager/blob/master/src/PackageRepository.php)

I parse the given URL to check if it is a package name without hosting name and if so I ask packagist to get the associated repo url:

```php
if (preg_match('`^([^/:@]*)/([^/\.]*)$`', $url, $m)) {
    $client = new Client(['verify' => config('packager.curl_verify_cert')]);
    try {
        $response = $client->get(sprintf('https://packagist.org/packages/%s/%s.json', $m[1], $m[2]));
        $json = json_decode($response->getBody()->getContents());
        $this->origin = $json->package->repository;
    } catch (GuzzleHttp\Exception\ClientException $e) {
        throw new RuntimeException('Package not found on packagist');
    }
}
```

If given URL is a full URL, I get the pieces:

```php
$regex = [
    '`^https?://([^/]*)/([^/]*)/([^./]*).*$`',
    '`^git@([^:]*):([^/]*)/([^.]*)\.git$`'
];

foreach ($regex as $rx) {
    if (preg_match($rx, $this->origin, $m)) {
        $this->host = $m[1];
        $this->vendor = $m[2];
        $this->name = $m[3];
        return $this;
    }
}
```

To get the zip url, I have an array of hosting solutions to retrieve the zip path:

```php
$urls = [
    'github.com'    => 'https://:host/:vendor/:name/archive/:branch.zip',
    'gitlab.com'    => 'https://:host/:vendor/:name/-/archive/:branch/:name-:branch.zip',
    'bitbucket.org' => 'https://:host/:vendor/:name/get/:branch.zip',
];
```

To be more flexible, I added an empty array in the configuration file, this array will be merged with the existent one:

```php
/*
 * For other public repositories. Enter the host and the associated url template
 * to allow zip files to be downloaded.
 */
'repositories' => [
    //'personal.repo.com' => 'https://:host/:vendor/:name/archive/:branch.zip',
]
```

### Tests

I added tests to check if the parser correctly works, see [IntegratedTest.php#L10](https://github.com/sebastienheyd/laravel-packager/blob/83a3b4083d36aaab598a81e18cacdcac26f00f8d/tests/IntegratedTest.php#L10)

### Small fixes

I had to add a micro delay to display the progress bar correctly in the [ProgressBar.php#L47](https://github.com/sebastienheyd/laravel-packager/blob/83a3b4083d36aaab598a81e18cacdcac26f00f8d/src/ProgressBar.php#L47) file.

I had to set an more important timeout for process (5 minutes) in file [Conveyor.php#L173](https://github.com/sebastienheyd/laravel-packager/blob/83a3b4083d36aaab598a81e18cacdcac26f00f8d/src/Conveyor.php#L173), my composer.json is heavy and when testing it fails because composer has not enough time to finish. Maybe this can be an configuration option?