### PR TITLE
Fix remove non-empty vendor directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,10 @@ All Notable changes to Packager will be documented in this file.
 
 ### Updated
 - Support for Laravel 7 and PHPUnit 9.
-- `packager:new` now also supports separating vendor and name with a forward slash.
+- `packager:new` and `packager:remove` now also supports separating vendor and name with a forward slash.
+
+### Fixed
+- Fix deletion of vendor directory when not empty
 
 ## Version 2.4
 

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -66,7 +66,7 @@ class NewPackage extends Command
         $name = $this->argument('name');
 
         if (strstr($vendor, '/')) {
-            list($vendor, $name) = explode('/', $vendor);
+            [$vendor, $name] = explode('/', $vendor);
         }
 
         // Defining vendor/package, optionally defined interactively

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -65,10 +65,8 @@ class NewPackage extends Command
         $vendor = $this->argument('vendor');
         $name = $this->argument('name');
 
-        if (stripos($vendor, '/') > 0) {
-            $part = explode('/', $vendor);
-            $vendor = $part[0];
-            $name = $part[1];
+        if (strstr($vendor, '/')) {
+            list($vendor, $name) = explode('/', $vendor);
         }
 
         // Defining vendor/package, optionally defined interactively

--- a/src/Commands/RemovePackage.php
+++ b/src/Commands/RemovePackage.php
@@ -20,7 +20,7 @@ class RemovePackage extends Command
      * The name and signature of the console command.
      * @var string
      */
-    protected $signature = 'packager:remove {vendor} {name}';
+    protected $signature = 'packager:remove {vendor} {name?}';
 
     /**
      * The console command description.
@@ -63,8 +63,15 @@ class RemovePackage extends Command
         $this->startProgressBar(4);
 
         // Defining vendor/package
-        $this->conveyor->vendor($this->argument('vendor'));
-        $this->conveyor->package($this->argument('name'));
+        $vendor = $this->argument('vendor');
+        $name = $this->argument('name');
+
+        if (strstr($vendor, '/')) {
+            [$vendor, $name] = explode('/', $vendor);
+        }
+
+        $this->conveyor->vendor($vendor);
+        $this->conveyor->package($name);
 
         // Start removing the package
         $this->info('Removing package '.$this->conveyor->vendor().'\\'.$this->conveyor->package().'...');
@@ -82,8 +89,12 @@ class RemovePackage extends Command
 
         // Remove the vendor directory, if agreed to
         if ($this->confirm('Do you want to remove the vendor directory? [y|N]')) {
-            $this->info('removing vendor directory...');
-            $this->conveyor->removeDir($this->conveyor->vendorPath());
+            if (count(array_diff(scandir($this->conveyor->vendorPath()), ['.', '..'])) !== 0) {
+                $this->warn('vendor directory is not empty, continuing...');
+            } else {
+                $this->info('removing vendor directory...');
+                $this->conveyor->removeDir($this->conveyor->vendorPath());
+            }
         } else {
             $this->info('Continuing...');
         }

--- a/src/Commands/RemovePackage.php
+++ b/src/Commands/RemovePackage.php
@@ -89,7 +89,7 @@ class RemovePackage extends Command
 
         // Remove the vendor directory, if agreed to
         if ($this->confirm('Do you want to remove the vendor directory? [y|N]')) {
-            if (count(array_diff(scandir($this->conveyor->vendorPath()), ['.', '..'])) !== 0) {
+            if (count(scandir($this->conveyor->vendorPath())) !== 2) {
                 $this->warn('vendor directory is not empty, continuing...');
             } else {
                 $this->info('removing vendor directory...');


### PR DESCRIPTION
Hi! Me again :)

This PR will fix the remove of non empty vendor directory.

### The problem

```
php artisan packager:git https://github.com/sebastienheyd/boilerplate
php artisan packager:git https://github.com/sebastienheyd/boilerplate-media-manager
php artisan packager:remove sebastienheyd boilerplate-media-manager
```
The whole folder `packages/sebastienheyd` is deleted instead of only `packages/sebastienheyd/boilerplate-media-manager` when you answer yes to "Do you want to remove the vendor directory?"

### The fix

A simple check if vendor directory is empty or not, if not a warn appears and the script continue.

https://github.com/sebastienheyd/laravel-packager/blob/ac1cdcf93765b069a5f4f86e00738171c57b2c8c/src/Commands/RemovePackage.php#L92-L97

### Bonus

Like `packager:new` I added the possibility to use `vendor/package` with `packager:remove` and took the opportunity to rewrite the explode in a more elegant way ;)

https://github.com/sebastienheyd/laravel-packager/blob/4125832499b82de6130157a995166ab444bbdf3a/src/Commands/RemovePackage.php#L65-L74

I don't writed tests this time, I think this is useless for so small fixes