### PR TITLE
Fix vendor-name package-name not converted to studly case

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@ All Notable changes to Packager will be documented in this file.
 - Support for Laravel 7 and PHPUnit 9.
 - `packager:new` now also supports separating vendor and name with a forward slash.
 
+### Fixed
+- vendor-name and package-name not converted to StudlyCase with `packager:new`
+
 ## Version 2.4
 
 ### Added

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -114,8 +114,8 @@ class NewPackage extends Command
             ':lc:vendor',
             ':lc:package',
         ], [
-            $this->conveyor->vendor(),
-            $this->conveyor->package(),
+            $this->conveyor->vendorStudly(),
+            $this->conveyor->packageStudly(),
             strtolower($this->conveyor->vendor()),
             strtolower($this->conveyor->package()),
         ]);

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -43,6 +43,16 @@ class Conveyor
     }
 
     /**
+     * Get the vendor name converted to StudlyCase.
+     *
+     * @return string|RuntimeException
+     */
+    public function vendorStudly()
+    {
+        return Str::studly($this->vendor());
+    }
+
+    /**
      * Set or get the package name.
      *
      * @param string $package
@@ -59,6 +69,16 @@ class Conveyor
         }
 
         return $this->package;
+    }
+
+    /**
+     * Get the package name converted to StudlyCase.
+     *
+     * @return string|RuntimeException
+     */
+    public function packageStudly()
+    {
+        return Str::studly($this->package());
     }
 
     /**

--- a/src/FileHandler.php
+++ b/src/FileHandler.php
@@ -169,7 +169,7 @@ trait FileHandler
     {
         $bindings = [
             [':uc:vendor', ':uc:package', ':lc:vendor', ':lc:package'],
-            [$this->vendor(), $this->package(), strtolower($this->vendor()), strtolower($this->package())],
+            [$this->vendorStudly(), $this->packageStudly(), strtolower($this->vendor()), strtolower($this->package())],
         ];
 
         $rewrites = require ($manifest === null) ? [

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -22,6 +22,15 @@ class IntegratedTest extends TestCase
         $this->assertStringContainsString('MyVendor/MyPackage', $composer);
     }
 
+    public function test_new_package_studly_install()
+    {
+        Artisan::call('packager:new', ['vendor' => 'my-vendor', 'name' => 'my-package']);
+
+        $this->seeInConsoleOutput('Package created successfully!');
+        $this->assertStringContainsString('my-vendor/my-package', file_get_contents(base_path('composer.json')));
+        $this->assertTrue(is_file(base_path('packages/my-vendor/my-package/src/MyPackageServiceProvider.php')));
+    }
+
     public function test_new_package_is_installed_from_custom_skeleton()
     {
         Artisan::call('packager:new', [


### PR DESCRIPTION
Hi!

This PR completes #97 with tests and fix StyleCI issues.

This feature is a must-have, a lot of people use the kebab-case or snake_case as vendor name or package name. 

Without this fix you can't use `packager:new` to create a new package with the default skeleton, it's a pity.

Hope you'll enjoy