### PR TITLE
Use of symlink with existing packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ All Notable changes to Packager will be documented in this file.
 ### Updated
 - Support for Laravel 7 and PHPUnit 9.
 - `packager:new` now also supports separating vendor and name with a forward slash.
+- `symlink` option is set to true as default for repositories in `composer.json`
 
 ## Version 2.4
 

--- a/src/Commands/GitPackage.php
+++ b/src/Commands/GitPackage.php
@@ -88,7 +88,7 @@ class GitPackage extends Command
 
         // Clone the repository
         $this->info('Cloning repository...');
-        exec("git clone $source ".$this->conveyor->packagePath(), $output, $exit_code);
+        exec("git clone -q $source ".$this->conveyor->packagePath(), $output, $exit_code);
 
         if ($exit_code != 0) {
             $this->error('Unable to clone repository');

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -122,6 +122,9 @@ class Conveyor
         $params = json_encode([
             'type' => 'path',
             'url' => $this->packagePath(),
+            'options' => [
+                'symlink' => true,
+            ],
         ]);
         $command = [
             'composer',
@@ -150,7 +153,7 @@ class Conveyor
         return $this->runProcess([
             'composer',
             'require',
-            $this->vendor.'/'.$this->package,
+            $this->vendor.'/'.$this->package.':@dev',
         ]);
     }
 

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -11,6 +11,7 @@ class IntegratedTest extends TestCase
         Artisan::call('packager:new', ['vendor' => 'MyVendor', 'name' => 'MyPackage']);
 
         $this->seeInConsoleOutput('Package created successfully!');
+        $this->assertTrue(is_link(base_path('vendor/myvendor/mypackage')));
     }
 
     public function test_new_package_is_installed()
@@ -35,12 +36,30 @@ class IntegratedTest extends TestCase
         $this->assertStringContainsString('AnotherVendor/AnotherPackage', $composer);
     }
 
-    public function test_get_existing_package()
+    public function test_get_package()
     {
         Artisan::call('packager:get',
             ['url' => 'https://github.com/Jeroen-G/packager-skeleton', 'vendor' => 'MyVendor', 'name' => 'MyPackage']);
 
         $this->seeInConsoleOutput('Package downloaded successfully!');
+    }
+
+    public function test_get_existing_package_with_git()
+    {
+        Artisan::call('packager:git',
+            ['url' => 'https://github.com/Seldaek/monolog', 'vendor' => 'monolog', 'name' => 'monolog']);
+
+        $this->seeInConsoleOutput('Package cloned successfully!');
+        $this->assertTrue(is_link(base_path('vendor/monolog/monolog')));
+    }
+
+    public function test_get_existing_package_with_get()
+    {
+        Artisan::call('packager:get',
+            ['url' => 'https://github.com/Seldaek/monolog', 'vendor' => 'monolog', 'name' => 'monolog']);
+
+        $this->seeInConsoleOutput('Package downloaded successfully!');
+        $this->assertTrue(is_link(base_path('vendor/monolog/monolog')));
     }
 
     public function test_list_packages()


### PR DESCRIPTION
Me again... :)

When `prefer-stable` is `true` in your project's `composer.json`, Composer will get the package from packagist and install it, he will not care about your local package, in spite of the fact that there is a repository with a path declared in your `composer.json`.

Example :

```
php artisan packager:git https://github.com/Seldaek/monolog monolog monolog
```
As you can see in your vendor folder, `monolog/monolog` is a folder instead of a symlink to `packages/monolog/monolog`. The version installed come from packagist instead from the local folder.

The solution is to force to use symlink in your composer.json, see [https://getcomposer.org/doc/05-repositories.md#path](https://getcomposer.org/doc/05-repositories.md#path)

But this is not sufficient, you also have to say to composer to require the package as a `dev` version with `@dev`, this is like requiring `dev-*` package.

This PR will fix this.