### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY:help test clean
+.DEFAULT_GOAL=help
+
+help:
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+composer.phar:
+	@curl -sS https://getcomposer.org/installer | php -- --filename=composer.phar
+	@chmod +x composer.phar
+
+vendor: composer.json
+	@./composer.phar update --optimize-autoloader --no-suggest
+
+tests: composer.phar vendor phpunit.xml ## Launch test
+	@php vendor/bin/phpunit
+
+clean: ## Remove files needed for tests
+	@rm -rf report testbench vendor .phpunit.result.cache composer.lock composer.phar


### PR DESCRIPTION
My last PR for the moment, I promise! :)

A simple `Makefile`.

I don't know if you use `make` or not, but this is very useful to automate the launch of unit tests when developing on your package. With this PR, you just have to go in your package folder and run `make tests` and that's it (of course you must have installed `make` before).

The command will get `composer.phar`, install the required packages and run the tests. If you rerun the command, it will just run the tests without reinstalling the whole vendor folder (only if you don't modify composer.json). This the magic of `make`

`make clean` will remove all files and folders needed by the tests.