### PR TITLE
Lumen config_path() error fix

### DIFF
--- a/src/PackagerServiceProvider.php
+++ b/src/PackagerServiceProvider.php
@@ -39,6 +39,13 @@ class PackagerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        /* Lumen Fix for error "Call to undefined function JeroenG\Packager\config_path()" */
+        if (!function_exists('config_path')) {
+            function config_path($path = '') {
+                return app()->basePath().DIRECTORY_SEPARATOR.'config' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+            }
+        }
+        
         $this->publishes([
             __DIR__.'/../config/packager.php' => config_path('packager.php'),
         ]);


### PR DESCRIPTION
Lumen fix for the error `Call to undefined function JeroenG\Packager\config_path()` when trying to run any packager command on lumen.
![image](https://user-images.githubusercontent.com/7644807/92134047-af927380-ee26-11ea-8663-b6e678a2c487.png)
