### PR TITLE
Validate package and vendor names for new packages

### DIFF
--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -23,7 +23,7 @@ class NewPackage extends Command
      * The name and signature of the console command.
      * @var string
      */
-    protected $signature = 'packager:new {vendor} {name?} {--i} {--skeleton=}';
+    protected $signature = 'packager:new {vendor?} {name?} {--i} {--skeleton=}';
 
     /**
      * The console command description.
@@ -90,6 +90,10 @@ class NewPackage extends Command
         } else {
             $this->conveyor->vendor($vendor);
             $this->conveyor->package($name);
+        }
+
+
+            return 1;
         }
 
         // Start creating the package
@@ -198,7 +202,7 @@ class NewPackage extends Command
 
     private function validateInput()
     {
-        return Validator::make($this->arguments(), [
+        return Validator::make(compact('vendor', 'name'), [
             'vendor' => new ValidClassName,
             'name' => new ValidClassName,
         ]);

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -62,15 +62,6 @@ class NewPackage extends Command
      */
     public function handle()
     {
-        // Validate the vendor and package names
-        $validator = $this->validateInput();
-
-        if ($validator->fails()) {
-            $this->showErrors($validator);
-
-            return 1;
-        }
-
         // Start the progress bar
         $this->startProgressBar(6);
 
@@ -92,6 +83,11 @@ class NewPackage extends Command
             $this->conveyor->package($name);
         }
 
+        // Validate the vendor and package names
+        $validator = $this->validateInput($this->conveyor->vendor(), $this->conveyor->package());
+
+        if ($validator->fails()) {
+            $this->showErrors($validator);
 
             return 1;
         }
@@ -200,7 +196,7 @@ class NewPackage extends Command
         ]);
     }
 
-    private function validateInput()
+    private function validateInput(string $vendor, string $name)
     {
         return Validator::make(compact('vendor', 'name'), [
             'vendor' => new ValidClassName,

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -67,6 +67,7 @@ class NewPackage extends Command
 
         if ($validator->fails()) {
             $this->showErrors($validator);
+
             return 1;
         }
 

--- a/src/ValidationRules/ValidClassName.php
+++ b/src/ValidationRules/ValidClassName.php
@@ -15,6 +15,6 @@ class ValidClassName implements Rule
 
     public function message()
     {
-        return 'The :attribute must conform to a valid PHP classname.';
+        return 'The package :attribute must conform to a valid PHP classname.';
     }
 }

--- a/src/ValidationRules/ValidClassName.php
+++ b/src/ValidationRules/ValidClassName.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace JeroenG\Packager\ValidationRules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class ValidClassName implements Rule
+{
+    public $pattern = '/^[a-zA-Z_-\x80-\xff][a-zA-Z0-9_-\x80-\xff]*$/';
+
+    public function passes($attribute, $value)
+    {
+        return preg_match($this->pattern, $value);
+    }
+
+    public function message()
+    {
+        return 'The :attribute must conform to a valid PHP classname.';
+    }
+}

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -32,6 +32,21 @@ class IntegratedTest extends TestCase
         $this->assertTrue(is_file(base_path('packages/my-vendor/my-package/src/MyPackageServiceProvider.php')));
     }
 
+    public function test_new_package_name_should_be_valid()
+    {
+        Artisan::call('packager:new', ['vendor' => 'my-vendor', 'name' => '1234-Invalid']);
+        $this->seeInConsoleOutput('Package was not created. Please choose a valid name.');
+        $this->assertFalse(is_file(base_path('packages/my-vendor/4-Invalid/src/1234InvalidServiceProvider.php')));
+
+    }
+
+    public function test_new_package_vendor_name_should_be_valid()
+    {
+        Artisan::call('packager:new', ['vendor' => '1234-invalid', 'name' => 'my-package']);
+        $this->seeInConsoleOutput('Package was not created. Please choose a valid name.');
+        $this->assertFalse(is_file(base_path('packages/1234-invalid/my-package/src/MyPackageServiceProvider.php')));
+    }
+
     public function test_new_package_is_installed_from_custom_skeleton()
     {
         Artisan::call('packager:new', [

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -37,7 +37,6 @@ class IntegratedTest extends TestCase
         Artisan::call('packager:new', ['vendor' => 'my-vendor', 'name' => '1234-Invalid']);
         $this->seeInConsoleOutput('Package was not created. Please choose a valid name.');
         $this->assertFalse(is_file(base_path('packages/my-vendor/4-Invalid/src/1234InvalidServiceProvider.php')));
-
     }
 
     public function test_new_package_vendor_name_should_be_valid()

--- a/tests/IntegratedTest.php
+++ b/tests/IntegratedTest.php
@@ -39,11 +39,33 @@ class IntegratedTest extends TestCase
         $this->assertFalse(is_file(base_path('packages/my-vendor/4-Invalid/src/1234InvalidServiceProvider.php')));
     }
 
+    public function test_new_package_name_in_interactive_mode_should_be_valid()
+    {
+        $this->artisan('packager:new', ['--i' => true])
+            ->expectsQuestion('What will be the vendor name?', 'my-vendor')
+            ->expectsQuestion('What will be the package name?', '1234-Invalid')
+            ->expectsOutput('Package was not created. Please choose a valid name.')
+            ->assertExitCode(1);
+
+        $this->assertFalse(is_file(base_path('packages/my-vendor/4-Invalid/src/1234InvalidServiceProvider.php')));
+    }
+
     public function test_new_package_vendor_name_should_be_valid()
     {
         Artisan::call('packager:new', ['vendor' => '1234-invalid', 'name' => 'my-package']);
         $this->seeInConsoleOutput('Package was not created. Please choose a valid name.');
         $this->assertFalse(is_file(base_path('packages/1234-invalid/my-package/src/MyPackageServiceProvider.php')));
+    }
+
+    public function test_new_package_vendor_name_in_interactive_mode_should_be_valid()
+    {
+        $this->artisan('packager:new', ['--i' => true])
+            ->expectsQuestion('What will be the vendor name?', '1234-invalid')
+            ->expectsQuestion('What will be the package name?', 'my-package')
+            ->expectsOutput('Package was not created. Please choose a valid name.')
+            ->assertExitCode(1);
+
+        $this->assertFalse(is_file(base_path('packages/my-vendor/4-Invalid/src/1234InvalidServiceProvider.php')));
     }
 
     public function test_new_package_is_installed_from_custom_skeleton()


### PR DESCRIPTION
This MR validates all vendor and package names against the regex for valid PHP class names as suggested in #80.
Closes #80 

## What has been done
- Added a custom validator `ValidClassName` which validates an input against a modified regex for valid PHP classnames, which also **allows dashes**, as they are already converted into valid PHP classes. 
- Validate the `vendor` and `name` inputs for the artisan command `packager:new` against this custom validator
- Added PHPunit tests

## How to test 
- Try to create a new package with an invalid vendor name (e.g. `123Vendor`) and assert that an error is shown and no package was created.
- Try to create a new package with an invalid package name (e.g. `123Package`) and assert that an error is shown and no package was created.