### PR TITLE
Add test scripts to composer file for easy package testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,12 @@
     "suggest": {
         "sensiolabs/security-checker": "Required to use the security check command"
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit --no-coverage",
+        "test-f": "vendor/bin/phpunit --no-coverage --filter",
+        "test-coverage": "vendor/bin/phpunit",
+        "test-coverage-f": "vendor/bin/phpunit --filter"
+    },
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
## What has been done
- Added some test options to the composer `scripts` section
- This allows to run all PHPunit tests using `composer test` to run the full suite. 
- You can also run the PHPunit tests without code coverage report (`composer test-f`) to speed up running the tests. 
- You can also filter down to a specific test using `composer test-f {test name}` or `composer test-coverage-f {test name}`.
