### PR TITLE
Allow kebab-case to be used for package and vendor names - fixes #132

### DIFF
--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -123,11 +123,15 @@ class NewPackage extends Command
             ':uc:package',
             ':lc:vendor',
             ':lc:package',
+            ':kc:vendor',
+            ':kc:package',
         ], [
             $this->conveyor->vendorStudly(),
             $this->conveyor->packageStudly(),
             strtolower($this->conveyor->vendor()),
             strtolower($this->conveyor->package()),
+            $this->conveyor->vendorKebab(),
+            $this->conveyor->packageKebab(),
         ]);
 
         if ($this->option('i')) {

--- a/src/Conveyor.php
+++ b/src/Conveyor.php
@@ -53,6 +53,16 @@ class Conveyor
     }
 
     /**
+     * Get the vendor name converted to kebab-case.
+     *
+     * @return string|RuntimeException
+     */
+    public function vendorKebab()
+    {
+        return Str::kebab($this->vendor());
+    }
+
+    /**
      * Set or get the package name.
      *
      * @param string $package
@@ -79,6 +89,16 @@ class Conveyor
     public function packageStudly()
     {
         return Str::studly($this->package());
+    }
+
+    /**
+     * Get the package name converted to kebab-case.
+     *
+     * @return string|RuntimeException
+     */
+    public function packageKebab()
+    {
+        return Str::kebab($this->package());
     }
 
     /**


### PR DESCRIPTION
Provides the functionality suggested in https://github.com/Jeroen-G/laravel-packager/issues/132 .

After this PR, packager skeletons can use two more keywords, and they'll automatically be substituted for the right thing by Packager:

```diff
            ':uc:vendor', // MyVendorName
            ':uc:package', // MyPackageName
            ':lc:vendor', // myvendorname
            ':lc:package', // mypackagename
+            ':kc:vendor', // my-vendor-name
+            ':kc:package', // my-package-name
```

This PR does NOT make Packager use these new keywords anywhere (by default) - it just adds the functionality for _skeletons_ to include those keywords. If they do, Packager will replace them. 

It just adds a minor functionality, so it's a non-breaking change. I see no reason for it not to be merged & tagged as `2.6.1` - @Jeroen-G if you do please let me know.

---

Also @Jeroen-G after this PR is merged, I can also submit a PR to [Jeroen-G/packager-skeleton](https://github.com/Jeroen-G/packager-skeleton), so that it uses kebab-case instead of lowercase. I believe that's better for most projects but... you might not - it's a matter of opinion. Let me know if you want a PR there too.