### PR TITLE
document kebab-case as the default way to create packages

### DIFF
--- a/config/packager.php
+++ b/config/packager.php
@@ -25,8 +25,8 @@ return [
     /*
      * You can set defaults for the following placeholders.
      */
-    'author_name' => 'author name',
-    'author_email' => 'author email',
-    'author_homepage' => 'author homepage',
-    'license' => 'license',
+    'author_name' => 'Author Name',
+    'author_email' => 'author@email.com',
+    'author_homepage' => 'http://author.com',
+    'license' => 'MIT',
 ];

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ $ php artisan vendor:publish --provider="JeroenG\Packager\PackagerServiceProvide
 ### New
 **Command:**
 ```bash
-$ php artisan packager:new MyVendor MyPackage
+$ php artisan packager:new my-vendor my-package
 ```
 
 **Result:**
@@ -49,13 +49,13 @@ The command will handle practically everything for you. It will create a package
 
 **Options:**
 ```bash
-$ php artisan packager:new MyVendor MyPackage --i
+$ php artisan packager:new my-vendor my-package --i
 $ php artisan packager:new --i
 ```
 The package will be created interactively, allowing to configure everything in the package's `composer.json`, such as the license and package description.
 
 ```bash
-$ php artisan packager:new MyVendor/MyPackage
+$ php artisan packager:new my-vendor/my-package
 ```
 Alternatively you may also define your vendor and name with a forward slash instead of a space.
 
@@ -78,8 +78,8 @@ If the `packager:git` command is used, the entire Git repository is cloned. If `
 **Options:**
 ```bash
 $ php artisan packager:get https://github.com/author/repository --branch=develop
-$ php artisan packager:get https://github.com/author/repository MyVendor MyPackage
-$ php artisan packager:git https://github.com/author/repository MyVendor MyPackage
+$ php artisan packager:get https://github.com/author/repository my-vendor my-package
+$ php artisan packager:git https://github.com/author/repository my-vendor my-package
 ```
 It is possible to specify a branch with the `--branch` option. If you specify a vendor and name directly after the url, those will be used instead of the pieces of the url.
 
@@ -100,7 +100,7 @@ Add the following to phpunit.xml (under the other testsuites) in order to run th
 
 **Options:**
 ```bash
-$ php artisan packager:tests MyVendor MyPackage
+$ php artisan packager:tests my-vendor my-package
 ```
 
 **Remarks:**
@@ -124,29 +124,29 @@ The packages are displayed with information on the git status (branch, commit di
 ### Remove
 **Command:**
 ```bash
-$ php artisan packager:remove MyVendor MyPackage
+$ php artisan packager:remove my-vendor my-package
 ```
 
 **Result:**
-The `MyVendor\MyPackage` package is deleted, including its references in `composer.json` and `config/app.php`.
+The `my-vendor\my-package` package is deleted, including its references in `composer.json` and `config/app.php`.
 
 ### Publish
 **Command:**
 ```bash
-$ php artisan packager:publish MyVendor MyPackage https://github.com/myvendor/mypackage
+$ php artisan packager:publish my-vendor my-package https://github.com/my-vendor/my-package
 ```
 
 **Result:**
-The `MyVendor\MyPackage` package will be published to Github using the provided url.
+The `my-vendor\my-package` package will be published to Github using the provided url.
 
 ### Check
 **Command:**
 ```bash
-$ php artisan packager:check MyVendor MyPackage
+$ php artisan packager:check my-vendor my-package
 ```
 
 **Result:**
-The `MyVendor\MyPackage` package will be checked for security vulnerabilities using SensioLabs security checker.
+The `my-vendor\my-package` package will be checked for security vulnerabilities using SensioLabs security checker.
 
 **Remarks**
 You first need to run

--- a/src/Commands/NewPackage.php
+++ b/src/Commands/NewPackage.php
@@ -65,8 +65,8 @@ class NewPackage extends Command
         // Start the progress bar
         $this->startProgressBar(6);
 
-        $vendor = $this->argument('vendor');
-        $name = $this->argument('name');
+        $vendor = $this->argument('vendor') ?? 'vendor-name';
+        $name = $this->argument('name') ?? 'package-name';
 
         if (strstr($vendor, '/')) {
             [$vendor, $name] = explode('/', $vendor);


### PR DESCRIPTION
@Jeroen-G I was working on a PR to your package skeleton, to make it use `kebab-case` by default, as talked about [here](https://github.com/Jeroen-G/laravel-packager/pull/135#issuecomment-782860851). But it turns out... no changes to the package skeleton are really needed 🥳  Turns out switching from StudlyCase to kebab-case is NOT a _functionality_ issue, but a _documentation_ issue. 

This is a long read, so strap in. But that's only because I've tried to be as thorough as possible, and think of all the implications.

## The Discovery

Even without PR https://github.com/Jeroen-G/laravel-packager/pull/135 which adds `:kc:vendor:` and `:kc:package:`, there is a VERY easy way to create proper kebab-cased folders & links with your existing package & package-skeleton. By just... using kebab-case as the inputs. I suspect you thought about supporting `my-vendor\my-package` as the input at some point and forgot about it 😀

Just inputting `my-vendor` and `my-package` fixes all inconsistencies/quirks we were talking about. For example:
- the folder names are kebab-cased:
![Screenshot 2021-02-26 at 10 31 42](https://user-images.githubusercontent.com/1032474/109275792-e1a4f100-781d-11eb-8513-63a87abd8ce4.png)
- the composer vendor and package names are using kebab-case, both inside the package's `composer.json` and inside the main app's `composer.json`:
![Screenshot 2021-02-26 at 10 33 50](https://user-images.githubusercontent.com/1032474/109276008-2761b980-781e-11eb-9893-b1af728e5000.png)
- the class names and namespaces still use StudlyCase as they should:
![Screenshot 2021-02-26 at 10 40 37](https://user-images.githubusercontent.com/1032474/109276782-1e251c80-781f-11eb-89db-9856633a47b0.png)

So basically... it all "just works". And the folders look exactly the same as they'll look inside `vendor` folder, once installed with Composer. The only reason people create the kind-of-confusing `MyVendor\MyPackage` is... because that's what the docs say 😂

## The Solution

This PR:
- changes _the docs_ to tell people to use kebab-case;
- changes the configuration with examples using the recommended casing, so that there's a higher chance to generate a valid `composer.json` file;
- adds defaults for vendor and package names to the `new` command, to highlight they should be `kebab-case`;

## The End Result

![2021-02-26 10 49 21](https://user-images.githubusercontent.com/1032474/109278103-d0a9af00-7820-11eb-9786-95e48b9013bc.gif)

## Backwards Compatibility

100% - it's just a documentation and defaults change. 

## Possible Side-Effects

There is _one_ use case where I foresee this change will be confusing. Imagine this scenario:
- developer generates a package using the old docs (so `MyVendor\MyPackage`);
- developer doesn't publish the package immediately, there's still stuff to do, leaves it for tomorrow;
- developer comes back the second day, checks out the docs on how to do something, but now the docs say he should publish or remove the package using `my-vendor/my-package`; runs the command, doesn't work because the package doesn't exist;

Since about ~230 people download this package every day, I imagine at least one person will run into this and be frustrated. But I guess if he/she doesn't figure it out, we can easily respond asking to try using `MyVendor\MyPackage` if that's how he's created the package... so it's an easy fix.

----

**Let me know what you think and if you don't agree with any/all of the changes here. I think it will reduce some confusion and bring some consistency, but you might think differently.**

Cheers!